### PR TITLE
Need to install the langkit/utils/ package as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url='https://www.adacore.com',
     description='A Python framework to generate language parsers',
     requires=['Mako', 'coverage', 'PyYAML', 'enum', 'enum34', 'funcy'],
-    packages=['langkit', 'langkit.expressions'],
+    packages=['langkit', 'langkit.utils', 'langkit.expressions'],
     package_data={'langkit': [
         'support/*.adb', 'support/*.ads', 'support/*.gpr',
         'templates/*.mako', 'templates/*/*.mako'


### PR DESCRIPTION
Older versions of langkit apparently had a utils.py, but it was now broken into several
python files which need to be installed