### PR TITLE
Introduce RefKind enum

### DIFF
--- a/langkit/support/langkit_support-lexical_env.ads
+++ b/langkit/support/langkit_support-lexical_env.ads
@@ -285,12 +285,26 @@ package Langkit_Support.Lexical_Env is
    -- Referenced environments --
    -----------------------------
 
+   type Ref_Kind is (Transitive, Prioritary, Normal);
+   --  Kind for a referenced env. Can be any of:
+   --
+   --  * transitive: The reference is transitive, eg. it will be explored in
+   --    every case (whether the lookup is recursive or not). It will be
+   --    explored before parent environments.
+   --
+   --  * prioritary: The reference is non transitive, eg. it will be
+   --    explored only if the lookup on the env is recursive. It will be
+   --    explored before parent environments.
+   --
+   --  * normal: The reference is non transitive, eg. it will be explored
+   --    only if the lookup on the env is recursive. It will be explored
+   --    after parent environments.
+
    type Refd_Env_State is (Active, Inactive);
 
    type Referenced_Env is record
-      Is_Transitive : Boolean := False;
-      --  Whether this reference is transitive. This changes the behavior of
-      --  the Get lookup operation.
+      Kind : Ref_Kind := Normal;
+      --  Kind for this referenced env.
 
       Getter        : Env_Getter;
       --  Closure to fetch the environment that is referenced
@@ -351,7 +365,7 @@ package Langkit_Support.Lexical_Env is
      (Self            : Lexical_Env;
       Referenced_From : Element_T;
       Resolver        : Lexical_Env_Resolver;
-      Transitive      : Boolean := False)
+      Kind            : Ref_Kind := Normal)
       with Pre => Self.Kind = Primary;
    --  Add a dynamic reference from Self to the lexical environment computed
    --  calling Resolver on Referenced_From. This makes the content of this
@@ -368,7 +382,7 @@ package Langkit_Support.Lexical_Env is
    procedure Reference
      (Self         : Lexical_Env;
       To_Reference : Lexical_Env;
-      Transitive   : Boolean := False)
+      Kind         : Ref_Kind := Normal)
       with Pre => Self.Kind = Primary;
    --  Add a static reference from Self to To_Reference. See above for the
    --  meaning of arguments.

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -308,7 +308,7 @@
                Env,
                Ref_Env_Nodes,
                ${ref_env.resolver.name}'Access,
-               ${ref_env.transitive});
+               ${ref_env.kind.value});
             Dec_Ref (Ref_Env_Nodes);
          end;
 

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -188,7 +188,7 @@ package body ${ada_lib_name}.Analysis.Implementation is
          Dest_Env            : Lexical_Env;
          Ref_Env_Nodes       : in out ${T.root_node.array.name};
          Resolver            : Lexical_Env_Resolver;
-         Transitive          : Boolean);
+         Kind                : Ref_Kind);
       --  Add referenced environments to Self.Self_Env. Calling this takes an
       --  ownership share for Ref_Env_Nodes.
    % endif
@@ -317,7 +317,7 @@ package body ${ada_lib_name}.Analysis.Implementation is
          Dest_Env            : Lexical_Env;
          Ref_Env_Nodes       : in out ${T.root_node.array.name};
          Resolver            : Lexical_Env_Resolver;
-         Transitive          : Boolean)
+         Kind                : Ref_Kind)
       is
       begin
          for N of Ref_Env_Nodes.Items loop
@@ -327,9 +327,7 @@ package body ${ada_lib_name}.Analysis.Implementation is
                      "attempt to add a referenced environment to a foreign"
                      & " unit";
                end if;
-               Reference
-                 (Dest_Env, N, Resolver,
-                  Transitive);
+               Reference (Dest_Env, N, Resolver, Kind);
             end if;
          end loop;
          Dec_Ref (Ref_Env_Nodes);


### PR DESCRIPTION
Instead of "Transitive" boolean value. Introduce a new value:
Prioritary, which makes a reference explored before parents, but still
not transitive.