### PR TITLE
S107-049 make build resistant to environment variables

### DIFF
--- a/langkit/libmanage.py
+++ b/langkit/libmanage.py
@@ -697,6 +697,7 @@ class ManageScript(object):
 
         result = ['-XBUILD_MODE={}'.format(build_mode),
                   '-XLIBRARY_TYPE={}'.format(library_type),
+                  '-XGPR_BUILD={}'.format(library_type),
                   '-XXMLADA_BUILD={}'.format(library_type)]
 
         enable_build_warnings = getattr(args, 'enable_build_warnings', False)


### PR DESCRIPTION
When we are enforcing the build of a particular variant
of the library through the setting of LIBRARY_TYPE and XMLADA_BUILD
we need to do the same for GPR_BUILD, as a safeguard against
contradicting environment variables.