### PR TITLE
Fix Node.Node_Env

### DIFF
--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -2513,6 +2513,16 @@ class ASTNodeType(BaseStructType):
         del entity_type
 
     @property
+    def effective_env_spec(self):
+        """
+        Return the env spec, for this node, whether it's defined on this node
+        or inherited from a parent node.
+        """
+        return self.env_spec if self.env_spec else (
+            self.base.effective_env_spec if self.base else None
+        )
+
+    @property
     def doc(self):
         result = super(ASTNodeType, self).doc
 

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -2407,7 +2407,6 @@ class ASTNodeType(BaseStructType):
 
         if env_spec:
             env_spec.ast_node = self
-        self.is_env_spec_inherited = env_spec is None
 
         self.env_spec = env_spec
         """

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -266,7 +266,7 @@
 
    ${exts.include_extension(ext)}
 
-   % if not cls.is_env_spec_inherited:
+   % if cls.env_spec:
 
       function ${cls.name}_Pre_Env_Actions
         (Self                : access ${type_name}'Class;
@@ -331,7 +331,7 @@
    ## Lexical Environments Handling ##
    ###################################
 
-   % if not cls.is_env_spec_inherited:
+   % if cls.env_spec:
 
    <% call_prop = cls.env_spec._render_field_access %>
 

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -1256,8 +1256,7 @@ package body ${ada_lib_name}.Implementation is
    is
    begin
 
-      <%self:case_dispatch
-        pred="${lambda n: n.env_spec and not n.is_env_spec_inherited}">
+      <%self:case_dispatch pred="${lambda n: n.env_spec}">
       <%def name="action(node)">
          return ${node.name}_Pre_Env_Actions
            (${node.name} (Self), Bound_Env, Root_Env, Add_To_Env_Only);
@@ -1275,8 +1274,7 @@ package body ${ada_lib_name}.Implementation is
      (Self                : access ${root_node_value_type}'Class;
       Bound_Env, Root_Env : AST_Envs.Lexical_Env) is
    begin
-      <%self:case_dispatch
-        pred="${(lambda n: n.env_spec and not n.is_env_spec_inherited)}">
+      <%self:case_dispatch pred="${lambda n: n.env_spec}">
       <%def name="action(n)">
          % if n.env_spec.post_actions:
          ${n.name}_Post_Env_Actions (${n.name} (Self), Bound_Env, Root_Env);

--- a/testsuite/tests/properties/node_env_concrete_subclass/main.py
+++ b/testsuite/tests/properties/node_env_concrete_subclass/main.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function
+
+print('main.py: Running...')
+
+
+import sys
+
+import libfoolang
+
+
+ctx = libfoolang.AnalysisContext()
+u = ctx.get_from_buffer('main.txt', 'def a; var d')
+if u.diagnostics:
+    for d in u.diagnostics:
+        print(d)
+    sys.exit(1)
+
+
+def_node = u.root.f_decls[0]
+var_node = u.root.f_decls[1]
+print('def_node lookup "a"', def_node.p_lookup('a'))
+print('var node lookup "d"', var_node.p_lookup('d'))
+
+print('main.py: Done.')

--- a/testsuite/tests/properties/node_env_concrete_subclass/test.out
+++ b/testsuite/tests/properties/node_env_concrete_subclass/test.out
@@ -1,0 +1,5 @@
+main.py: Running...
+def_node lookup "a" <Decl main.txt:1:1-1:6>
+var node lookup "d" <SubDecl main.txt:1:8-1:13>
+main.py: Done.
+Done

--- a/testsuite/tests/properties/node_env_concrete_subclass/test.py
+++ b/testsuite/tests/properties/node_env_concrete_subclass/test.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, division, print_function
+
+from langkit.dsl import ASTNode, Field, LookupKind as LK, T, abstract
+from langkit.envs import EnvSpec, add_env, add_to_env_kv
+from langkit.expressions import Self, langkit_property
+from langkit.parsers import Grammar, List
+
+from lexer_example import Token
+from utils import build_and_run
+
+"""
+Test that node_env works correctly for a subclass of a concrete node with an
+add_env directive.
+"""
+
+
+@abstract
+class FooNode(ASTNode):
+    pass
+
+
+class RootNode(FooNode):
+    env_spec = EnvSpec(add_env())
+    decls = Field()
+
+
+@abstract
+class BaseDecl(FooNode):
+
+    @langkit_property(public=True)
+    def lookup(n=T.Symbol):
+        return Self.env_lookup(Self.node_env, n)
+
+    @langkit_property()
+    def env_lookup(env=T.LexicalEnv, n=T.Symbol):
+        return env.get_first(n, lookup=LK.flat)
+
+
+class Decl(BaseDecl):
+    name = Field()
+    env_spec = EnvSpec(
+        add_to_env_kv(Self.name.symbol, Self),
+        add_env()
+    )
+
+
+class SubDecl(Decl):
+    pass
+
+
+class OtherDecl(BaseDecl):
+    name = Field()
+
+
+class Name(FooNode):
+    token_node = True
+
+
+g = Grammar('main_rule')
+g.add_rules(
+    main_rule=RootNode(List(g.decl | g.subdecl | g.other_decl, sep=";")),
+    decl=Decl('def', g.name),
+    other_decl=OtherDecl('def', 'var', g.name),
+    subdecl=SubDecl('var', g.name),
+    name=Name(Token.Identifier),
+)
+build_and_run(g, 'main.py')
+print('Done')

--- a/testsuite/tests/properties/node_env_concrete_subclass/test.yaml
+++ b/testsuite/tests/properties/node_env_concrete_subclass/test.yaml
@@ -1,0 +1,1 @@
+driver: python


### PR DESCRIPTION
Previous version was overcomplicated and didn't generate proper code for
a concrete subclass of a concrete base class.
