### PR TITLE
S701-037: Fix invalidation of env_getter cache.

### DIFF
--- a/langkit/support/langkit_support-lexical_env.ads
+++ b/langkit/support/langkit_support-lexical_env.ads
@@ -214,7 +214,8 @@ package Langkit_Support.Lexical_Env is
       --  unit.
 
       Owner : Unit_T := No_Unit;
-      --  Unit that owns this lexical environment
+      --  Unit that owns this lexical environment. Only Primary and Rebound
+      --  lexical env will have a non-null value for this field.
 
       Version : Version_Number := 0;
       --  Version of the unit when this reference was made. Used to determine

--- a/langkit/support/langkit_support-lexical_env.ads
+++ b/langkit/support/langkit_support-lexical_env.ads
@@ -63,9 +63,12 @@ generic
 
    type Unit_T is private;
    No_Unit : Unit_T;
-   with function Get_Version (Unit : Unit_T) return Version_Number;
-   --  Unit is passed solely for the Get_Version function, that is used in
-   --  cache invalidation.
+   with function Get_Unit_Version (Unit : Unit_T) return Version_Number;
+   --  Used to retrieve the version number of the given Unit, for cache
+   --  invalidation purposes.
+   with function Get_Context_Version (Unit : Unit_T) return Integer;
+   --  Used to retrieve the version number of the context associated with the
+   --  given Unit, for cache invalidation purposes.
 
    type Node_Type is private;
    type Node_Metadata is private;
@@ -759,6 +762,12 @@ package Langkit_Support.Lexical_Env is
 
                   Rebindings : Env_Rebindings;
                   --  Rebindings for this rebound environment
+
+                  Context_Version : Integer;
+                  --  Version of the context at the time of creation of this
+                  --  rebound env. This is used to determine if its content
+                  --  (in particular the Rebindings field) has become stale
+                  --  or not.
             end case;
       end case;
    end record;

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -2112,15 +2112,23 @@ package body ${ada_lib_name}.Implementation is
       return Create_Big_Integer (Left.Value - Right.Value);
    end "-";
 
-   -------------
-   -- Version --
-   -------------
+   ------------------
+   -- Unit_Version --
+   ------------------
 
-   function Version (Unit : Internal_Unit) return Version_Number is
+   function Unit_Version (Unit : Internal_Unit) return Version_Number is
    begin
       return Unit.Unit_Version;
-   end Version;
+   end Unit_Version;
 
+   ---------------------
+   -- Context_Version --
+   ---------------------
+
+   function Context_Version (Unit : Internal_Unit) return Integer is
+   begin
+      return Unit.Context.Reparse_Cache_Version;
+   end Context_Version;
    ----------------------
    -- Short_Text_Image --
    ----------------------

--- a/langkit/templates/pkg_implementation_spec_ada.mako
+++ b/langkit/templates/pkg_implementation_spec_ada.mako
@@ -138,9 +138,12 @@ private package ${ada_lib_name}.Implementation is
 
    No_Analysis_Unit : constant Internal_Unit := null;
 
-   function Version (Unit : Internal_Unit) return Version_Number;
+   function Unit_Version (Unit : Internal_Unit) return Version_Number;
    --  Return the version for Unit. Version is a number that is incremented
    --  every time Unit changes.
+
+   function Context_Version (Unit : Internal_Unit) return Integer;
+   --  Return the version of the analysis context associated with Unit
 
    type Ref_Category is (${", ".join(str(cat) for cat in ctx.ref_cats)});
    type Ref_Categories is array (Ref_Category) of Boolean;
@@ -152,7 +155,8 @@ private package ${ada_lib_name}.Implementation is
       Symbols                  => Symbols,
       Unit_T                   => Internal_Unit,
       No_Unit                  => No_Analysis_Unit,
-      Get_Version              => Version,
+      Get_Unit_Version         => Unit_Version,
+      Get_Context_Version      => Context_Version,
       Node_Type                => ${root_node_type_name},
       Node_Metadata            => ${T.env_md.name},
       No_Node                  => null,

--- a/testsuite/tests/langkit_support/lexical_env_equiv/support.ads
+++ b/testsuite/tests/langkit_support/lexical_env_equiv/support.ads
@@ -32,7 +32,8 @@ package Support is
    procedure Register_Rebinding (Node : Character; Rebinding : System.Address)
    is null;
 
-   function Get_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Unit_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Context_Version (Dummy : Boolean) return Integer is (0);
 
    type Ref_Category is (No_Cat);
    type Ref_Categories is array (Ref_Category) of Boolean;
@@ -50,7 +51,8 @@ package Support is
       Precomputed_Symbol       => Precomputed_Symbol,
       Symbols                  => Symbols,
       Unit_T                   => Boolean,
-      Get_Version              => Get_Version,
+      Get_Unit_Version         => Get_Unit_Version,
+      Get_Context_Version      => Get_Context_Version,
       No_Unit                  => False,
       Node_Type                => Character,
       Node_Metadata            => Metadata,

--- a/testsuite/tests/langkit_support/lexical_env_group/support.ads
+++ b/testsuite/tests/langkit_support/lexical_env_group/support.ads
@@ -32,7 +32,8 @@ package Support is
    procedure Register_Rebinding
      (Dummy_Node : Character; Dummy_Rebinding : System.Address) is null;
 
-   function Get_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Unit_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Context_Version (Dummy : Boolean) return Integer is (0);
 
    type Ref_Category is (No_Cat);
    type Ref_Categories is array (Ref_Category) of Boolean;
@@ -50,7 +51,8 @@ package Support is
       Precomputed_Symbol       => Precomputed_Symbol,
       Symbols                  => Symbols,
       Unit_T                   => Boolean,
-      Get_Version              => Get_Version,
+      Get_Unit_Version         => Get_Unit_Version,
+      Get_Context_Version      => Get_Context_Version,
       No_Unit                  => False,
       Node_Type                => Character,
       Node_Metadata            => Metadata,

--- a/testsuite/tests/langkit_support/lexical_env_image/support.ads
+++ b/testsuite/tests/langkit_support/lexical_env_image/support.ads
@@ -36,7 +36,8 @@ package Support is
    procedure Register_Rebinding
      (Node : String_Access; Rebinding : System.Address) is null;
 
-   function Get_Version (Dummy_B : Boolean) return Version_Number is (0);
+   function Get_Unit_Version (Dummy_B : Boolean) return Version_Number is (0);
+   function Get_Context_Version (Dummy : Boolean) return Integer is (0);
 
    type Ref_Category is (No_Cat);
    type Ref_Categories is array (Ref_Category) of Boolean;
@@ -53,7 +54,8 @@ package Support is
       Precomputed_Symbol       => Precomputed_Symbol,
       Symbols                  => Symbols,
       Unit_T                   => Boolean,
-      Get_Version              => Get_Version,
+      Get_Unit_Version         => Get_Unit_Version,
+      Get_Context_Version      => Get_Context_Version,
       No_Unit                  => False,
       Node_Type                => String_Access,
       Node_Metadata            => Metadata,

--- a/testsuite/tests/langkit_support/lexical_env_orphan/support.ads
+++ b/testsuite/tests/langkit_support/lexical_env_orphan/support.ads
@@ -32,7 +32,8 @@ package Support is
    procedure Register_Rebinding
      (Dummy_Node : Character; Dummy_Rebinding : System.Address) is null;
 
-   function Get_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Unit_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Context_Version (Dummy : Boolean) return Integer is (0);
 
    type Ref_Category is (No_Cat);
    type Ref_Categories is array (Ref_Category) of Boolean;
@@ -50,7 +51,8 @@ package Support is
       Precomputed_Symbol       => Precomputed_Symbol,
       Symbols                  => Symbols,
       Unit_T                   => Boolean,
-      Get_Version              => Get_Version,
+      Get_Unit_Version         => Get_Unit_Version,
+      Get_Context_Version      => Get_Context_Version,
       No_Unit                  => False,
       Node_Type                => Character,
       Node_Metadata            => Metadata,

--- a/testsuite/tests/langkit_support/lexical_env_rebound/support.ads
+++ b/testsuite/tests/langkit_support/lexical_env_rebound/support.ads
@@ -32,7 +32,8 @@ package Support is
    procedure Register_Rebinding
      (Dummy_Node : Character; Dummy_Rebinding : System.Address) is null;
 
-   function Get_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Unit_Version (Dummy : Boolean) return Version_Number is (0);
+   function Get_Context_Version (Dummy : Boolean) return Integer is (0);
 
    type Ref_Category is (No_Cat);
    type Ref_Categories is array (Ref_Category) of Boolean;
@@ -50,7 +51,8 @@ package Support is
       Precomputed_Symbol       => Precomputed_Symbol,
       Symbols                  => Symbols,
       Unit_T                   => Boolean,
-      Get_Version              => Get_Version,
+      Get_Unit_Version         => Get_Unit_Version,
+      Get_Context_Version      => Get_Context_Version,
       No_Unit                  => False,
       Node_Type                => Character,
       Node_Metadata            => Metadata,


### PR DESCRIPTION
The Is_Stale procedure was missing information to determine if rebindings
from a given rebound_env where still valid or not and would unsoundly
consider them valid all the time.

This fix adds a field to rebound environments indicating the version of
the context at the time the rebound env is created. Is_Stale now compares
this number with the current context version to determine if a cached
rebound_env is stale or not.