### PR TITLE
Remove tags from bare nodes

### DIFF
--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -2241,8 +2241,10 @@ class EntityType(StructType):
         return result
 
     def to_internal_expr(self, public_expr, context=None):
-        return ('({type} ({name}.Internal.Node), {name}.Internal.Info)'
-                .format(type=self.element_type.name, name=public_expr))
+        return ('({internal_node}, {public_entity}.Internal.Info)'.format(
+            internal_node=self.element_type.to_internal_expr(public_expr),
+            public_entity=public_expr
+        ))
 
 
 class ASTNodeType(BaseStructType):
@@ -3241,8 +3243,10 @@ class ASTNodeType(BaseStructType):
         return result
 
     def to_internal_expr(self, public_expr, context=None):
-        return ('{type} ({name}.Internal.Node)'
-                .format(type=self.name, name=public_expr))
+        return self.internal_conversion(
+            T.root_node,
+            '{}.Internal.Node'.format(public_expr)
+        )
 
     def internal_converter(self, from_type):
         """

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -3135,8 +3135,10 @@ class ASTNodeType(BaseStructType):
                 uses_envs=False,
                 doc='Return the last token used to parse this node.'
             )),
-            ('child_index', BuiltinField(
-                type=T.Int,
+            ('child_index', PropertyDef(
+                expr=None, prefix=None, type=T.Int,
+                public=True, external=True, uses_entity_info=False,
+                uses_envs=False,
                 doc="Return the 0-based index for Node in its parent's"
                     " children."
             )),

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -2355,6 +2355,12 @@ class ASTNodeType(BaseStructType):
             fields = self.builtin_properties() + fields
         self._init_fields(fields)
 
+        # Encode all field names for nodes so that there is no name collision
+        # when considering all fields from all nodes.
+        for f in fields:
+            if isinstance(f, BaseField):
+                f._internal_name = self.name + f.name
+
         # Make sure that all user fields for nodes are private
         for _, f in fields:
             with f.diagnostic_context:

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -47,28 +47,14 @@ def template_extensions(ctx):
     capi = ctx.c_api_settings
     root_entity = ctx.root_grammar_class.entity
 
-    # Name of the root AST node access type
-    type_name = ctx.root_grammar_class.name
-
-    # Name of the root AST node record type
-    value_type = type_name + names.Name('Type')
-
     # Name of the root AST node kind type
     kind_name = root_entity.api_name + names.Name('Kind_Type')
-
-    # Likewise, for the generic list type
-    glist_type_name = ctx.generic_list_type.name
-    glist_value_type = ctx.generic_list_type.name + names.Name('Type')
 
     return {
         'no_builtins': lambda ts: filter(lambda t: not t.is_builtin(), ts),
         'grammar_rule_type':     T.GrammarRule.c_type(capi).name,
         'default_grammar_rule':  capi.get_name('default_grammar_rule'),
-        'root_node_type_name':   type_name,
-        'root_node_value_type':  value_type,
         'root_node_kind_name':   kind_name,
-        'generic_list_type_name': glist_type_name,
-        'generic_list_value_type': glist_value_type,
         'root_entity':           root_entity,
         'entity_array':          root_entity.array.api_name,
         'ctx':                   ctx,

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -3236,8 +3236,10 @@ class ASTNodeType(BaseStructType):
         return self.snaps(True)
 
     def to_public_expr(self, internal_expr):
-        result = 'Wrap_Node ({}, {})'.format(internal_expr,
-                                             T.entity_info.nullexpr)
+        result = 'Wrap_Node ({}, {})'.format(
+            T.root_node.internal_conversion(self, internal_expr),
+            T.entity_info.nullexpr
+        )
         if not self.is_root_node:
             result += '.As_{}'.format(self.entity.api_name)
         return result

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -3300,15 +3300,15 @@ class ASTNodeType(BaseStructType):
 
         :param ASTNodeType|EntityType expr_type: Static type for `expr`'s
             result. For convenience, entity types are accepted and interpreted
-            as the bare node they wrap.
+            as the bare node they wrap, and non-nodes are returned as-is.
         :param str expr: Expression that returns a bare node.
         :return str: Expression that returns a node whose `self` is the type.
         """
         if expr_type.is_entity_type:
             expr_type = expr_type.element_type
 
-        # Avoid useless conversions
-        if self == expr_type:
+        # Avoid useless conversions and return as-is expressions for non-nodes
+        if not expr_type.is_ast_node or self == expr_type:
             return expr
 
         root_node_expr = (

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -2810,6 +2810,33 @@ class ASTNodeType(BaseStructType):
                 )
                 if not f.is_overriding]
 
+    def fields_to_initialize(self, include_inherited):
+        """
+        Return the list of fields to initialize for this node.
+
+        :param bool include_inherited: If true, include inheritted fields in
+            the returned list. Return only fields that were part of the
+            declaration of this node otherwise.
+        :rtype: list[BaseField]
+        """
+        return self.get_fields(
+            include_inherited=include_inherited,
+            predicate=lambda f: not f.abstract and not f.null
+        )
+
+    @property
+    @memoized
+    def has_fields_initializer(self):
+        """
+        Return whether this node has a kind-specific fields initializer
+        procedure.
+        """
+        if self.is_root_node:
+            return False
+
+        return (self.fields_to_initialize(include_inherited=False) or
+                self.base.has_fields_initializer)
+
     def c_type(self, c_api_settings):
         return CAPIType(c_api_settings, 'base_node')
 

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -1970,9 +1970,7 @@ class UserField(BaseField):
 class BuiltinField(UserField):
     """
     A built-in field is just like a UserField, except that its name has no
-    prefix. It is disregarded by the parsing machinery too. It is typically
-    used for fields on the root node that don't really exist/are added
-    manually.
+    prefix. It is typically used for fields of built-in structs.
     """
 
     prefix = None

--- a/langkit/expressions/base.py
+++ b/langkit/expressions/base.py
@@ -2449,11 +2449,13 @@ class GetSymbol(AbstractExpression):
             'Token node expected, but the input {} node is not a token node'
             .format(node.type.dsl_name)
         )
+
         return self.construct_static(node, abstract_expr=self)
 
     @staticmethod
     def construct_static(node_expr, abstract_expr=None):
-        return CallExpr('Sym', 'Get_Symbol', T.Symbol, [node_expr],
+        return CallExpr('Sym', 'Get_Symbol', T.Symbol,
+                        [node_expr.convert_node(T.root_node)],
                         abstract_expr=abstract_expr)
 
     def __repr__(self):

--- a/langkit/expressions/base.py
+++ b/langkit/expressions/base.py
@@ -3929,9 +3929,18 @@ class PropertyDef(AbstractNodeData):
 
     def require_untyped_wrapper(self):
         """
-        Tag this property as requiring an untyped wrapper function. This
-        wrapper is a function that takes Self and an Entity_Info record as
-        parameters and that return an entity.
+        Tag this property as requiring an untyped wrapper function.
+
+        Untyped wrappers take a root entity instead of a node as their first
+        formal. Regarding the return type::
+
+          * if the wrapped property returns an entity, the wrapper returns
+            the root entity;
+
+          * if the wrapped property returns a node, the wrapper returns the
+            root node.
+
+        These wrappers are used as callbacks in lexical environments.
         """
         self._requires_untyped_wrapper = True
 

--- a/langkit/expressions/boolean.py
+++ b/langkit/expressions/boolean.py
@@ -293,6 +293,8 @@ class OrderingTest(AbstractExpression):
                         self.LE: 'Less_Or_Equal',
                         self.GT: 'Greater_Than',
                         self.GE: 'Greater_Or_Equal'}[self.operator]
+            lhs = lhs.convert_node(T.root_node)
+            rhs = rhs.convert_node(T.root_node)
             return CallExpr('Node_Comp', 'Compare', T.Bool,
                             [lhs, rhs, relation], abstract_expr=self)
 

--- a/langkit/expressions/collections.py
+++ b/langkit/expressions/collections.py
@@ -418,6 +418,20 @@ class Map(CollectionExpression):
                             self.expr.type)
             self.static_type = element_type.array
 
+            ctx = get_context()
+            prop = PropertyDef.get()
+
+            # If needed, create temporaries to hold intermediate lists as
+            # generic lists and as root nodes.
+            if self.do_concat and self.expr.type.is_list_type:
+                self.concat_var_root = prop.vars.create('Concat_As_Root',
+                                                        T.root_node)
+                self.concat_var_generic = prop.vars.create(
+                    'Concat', ctx.generic_list_type)
+            else:
+                self.concat_var_root = None
+                self.concat_var_generic = None
+
             with iter_scope.parent.use():
                 super(Map.Expr, self).__init__('Map_Result',
                                                abstract_expr=abstract_expr)

--- a/langkit/expressions/structs.py
+++ b/langkit/expressions/structs.py
@@ -660,8 +660,8 @@ class FieldAccess(AbstractExpression):
                     self.receiver_expr.type, prefix
                 )
 
-            # If we're calling a property, then pass the arguments
             if isinstance(self.node_data, PropertyDef):
+                # If we're calling a property, then pass the arguments
 
                 # TODO: For the moment, the first argument is named Node for
                 # properties on node & entity types, and Self for other
@@ -711,6 +711,13 @@ class FieldAccess(AbstractExpression):
                     '{} => {}'.format(name, value)
                     for name, value in args
                 ))
+
+            elif self.node_data.abstract:
+                # Call the accessor for abstract fields
+                ret = 'Implementation.{} ({})'.format(
+                    self.node_data.internal_name,
+                    prefix
+                )
 
             else:
                 # If we reach this point, we know that we are accessing a

--- a/langkit/gdb/__init__.py
+++ b/langkit/gdb/__init__.py
@@ -26,7 +26,7 @@ def get_current_gdb_context():
     return global_context
 
 
-def setup(lib_name, astnode_names, prefix):
+def setup(lib_name, astnode_names, astnode_kinds, prefix):
     """
     Register helpers in GDB internals. This should be run when the generated
     library is actually loaded in GDB.
@@ -34,7 +34,7 @@ def setup(lib_name, astnode_names, prefix):
     global setup_done, gdb_printers, global_context
     setup_done = True
 
-    context = Context(lib_name, astnode_names, prefix)
+    context = Context(lib_name, astnode_names, astnode_kinds, prefix)
     global_context = context
 
     gdb_printers = printers.GDBPrettyPrinters(context)

--- a/langkit/gdb/context.py
+++ b/langkit/gdb/context.py
@@ -12,20 +12,33 @@ class Context(object):
     Holder for generated library-specific information.
     """
 
-    def __init__(self, lib_name, astnode_names, prefix):
+    def __init__(self, lib_name, astnode_names, astnode_kinds, prefix):
         """
         :param str lib_name: Lower-case name for the generated library.
 
         :param list[str] astnode_names: List of camel-with-mixed-case names for
             all node types.
 
+        :param dict[int, str] astnode_kinds: Mapping of kinds ('Enum_Rep) to
+            camel-with-mixed-case node names.
+
         :param str prefix: Prefix to use for command names.
         """
         self.lib_name = lib_name
         self.astnode_names = [Name(name) for name in astnode_names]
+        self.astnode_kinds = {kind: Name(name)
+                              for kind, name in astnode_kinds.items()}
         self.prefix = prefix
 
-        self.astnode_struct_names = self._astnode_struct_names()
+        self.root_node = self.astnode_names[0]
+        """
+        Name of the root node.
+        """
+
+        self.struct_name_to_astnodes = self._astnode_struct_names()
+        self.astnode_to_struct_names = {
+            v: k for k, v in self.struct_name_to_astnodes.items()
+        }
         self.entity_struct_names = self._entity_struct_names()
 
         self.reparse_debug_info()

--- a/langkit/gdb/context.py
+++ b/langkit/gdb/context.py
@@ -16,13 +16,13 @@ class Context(object):
         """
         :param str lib_name: Lower-case name for the generated library.
 
-        :param astnode_names: Set of lower-case names for all AST node types.
-        :type ast_node_names: set[str]
+        :param list[str] astnode_names: List of camel-with-mixed-case names for
+            all node types.
 
         :param str prefix: Prefix to use for command names.
         """
         self.lib_name = lib_name
-        self.astnode_names = astnode_names
+        self.astnode_names = [Name(name) for name in astnode_names]
         self.prefix = prefix
 
         self.astnode_struct_names = self._astnode_struct_names()
@@ -36,9 +36,8 @@ class Context(object):
         record names, as GDB will see them, to user-friendly ASTNode names.
         """
         return {
-            '{}__implementation__bare_{}_type'.format(
-                self.lib_name, name.lower()
-            ): Name.from_camel_with_underscores(name)
+            '{}__implementation__bare_{}_type'
+            .format(self.lib_name, name.lower): name
             for name in self.astnode_names
         }
 
@@ -48,10 +47,9 @@ class Context(object):
         corresponding entity records.
         """
         return {
-            '{}__implementation__internal_entity_{}'.format(
-                self.lib_name,
-                Name.from_camel_with_underscores(name).lower
-            ) for name in self.astnode_names
+            '{}__implementation__internal_entity_{}'
+            .format(self.lib_name, name.lower)
+            for name in self.astnode_names
         } | {
             '{}__implementation__internal_entity'.format(self.lib_name),
             '{}__implementation__ast_envs__entity'.format(self.lib_name),

--- a/langkit/gdb/utils.py
+++ b/langkit/gdb/utils.py
@@ -1,46 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
-import gdb
-
 from langkit.names import Name
 from langkit.utils import Colors, col
-
-
-system_address = gdb.lookup_type('system__address')
-
-
-def ptr_to_int(ptr_value):
-    """
-    Convert an access GDB value into the corresponding Python integer.
-    """
-    return int(ptr_value.cast(system_address))
-
-
-def tagged_field(record_value, field_name):
-    """
-    Helper to look for a field in a tagged record.
-
-    This is useful because we see tagged records in GDB as a record that
-    contains another record (for fields from the parent type) that contains
-    another record, etc.
-    """
-    while True:
-        try:
-            return record_value[field_name]
-        except gdb.error:
-            pass
-        try:
-            record_value = record_value['_parent']
-        except gdb.error:
-            raise gdb.error('There is no member {}'.format(field_name))
-
-
-def record_to_tag(record_value):
-    """
-    Assuming "record_value" is a tagged record value, return the corresponding
-    tag as a Python integer.
-    """
-    return ptr_to_int(tagged_field(record_value, '_tag'))
 
 
 def expr_repr(expr):

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -90,18 +90,14 @@
 
 
 <%def name="bare_field_decl(field)">
-   <% type_name = field.struct.value_type_name() %>
-
    function ${field.name}
-     (Node : access ${type_name}) return ${field.type.name};
+     (Node : ${field.struct.name}) return ${field.type.name};
 </%def>
 
 
 <%def name="bare_field_body(field)">
-   <% type_name = field.struct.value_type_name() %>
-
    function ${field.name}
-     (Node : access ${type_name}) return ${field.type.name}
+     (Node : ${field.struct.name}) return ${field.type.name}
    is
       <%def name="return_value(node_expr)">
          return ${field.type.extract_from_storage_expr(
@@ -238,12 +234,11 @@
 <%def name="private_decl(cls)">
 
    <%
-      type_name = cls.value_type_name()
       base_name = cls.base.name
       ext = ctx.ext('nodes', cls.raw_name, 'public_decls')
    %>
 
-   type ${type_name} is record
+   type ${cls.value_type_name()} is record
       Base : ${cls.base.value_type_name()};
       ${node_fields(cls, emit_null=False)}
    end record
@@ -256,7 +251,7 @@
          parse_fields = [f for f in fields if not f.is_user_field]
       %>
       procedure Initialize_Fields_For_${cls.kwless_raw_name}
-        (Self : access ${cls.value_type_name()}
+        (Self : ${cls.name}
          % for f in parse_fields:
          ; ${f.name} : ${f.type.name}
          % endfor
@@ -281,13 +276,13 @@
    % if cls.env_spec:
 
       function ${cls.name}_Pre_Env_Actions
-        (Self                : access ${type_name};
+        (Self                : ${cls.name};
          Bound_Env, Root_Env : AST_Envs.Lexical_Env;
          Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env;
 
       % if cls.env_spec.post_actions:
          procedure ${cls.name}_Post_Env_Actions
-           (Self                : access ${type_name};
+           (Self                : ${cls.name};
             Bound_Env, Root_Env : AST_Envs.Lexical_Env);
       % endif
 
@@ -505,7 +500,7 @@
    % endif
 
    function ${cls.name}_Pre_Env_Actions
-     (Self                : access ${type_name};
+     (Self                : ${cls.name};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env
    is
@@ -539,7 +534,7 @@
 
    % if cls.env_spec.post_actions:
       procedure ${cls.name}_Post_Env_Actions
-        (Self                : access ${type_name};
+        (Self                : ${cls.name};
          Bound_Env, Root_Env : AST_Envs.Lexical_Env)
       is
          use AST_Envs;
@@ -575,7 +570,7 @@
          parent_parse_fields = filter_parse_fields(parent_fields)
       %>
       procedure Initialize_Fields_For_${cls.kwless_raw_name}
-        (Self : access ${cls.value_type_name()}
+        (Self : ${cls.name}
          % for f in all_parse_fields:
          ; ${f.name} : ${f.type.name}
          % endfor

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -6,9 +6,9 @@
 
 <%def name="bare_node_converters(cls)">
    function ${cls.internal_converter(T.root_node)} is
-      new Ada.Unchecked_Conversion (${root_node_type_name}, ${cls.name});
+      new Ada.Unchecked_Conversion (${T.root_node.name}, ${cls.name});
    function ${T.root_node.internal_converter(cls)} is
-      new Ada.Unchecked_Conversion (${cls.name}, ${root_node_type_name});
+      new Ada.Unchecked_Conversion (${cls.name}, ${T.root_node.name});
 </%def>
 
 <%def name="public_incomplete_decl(cls)">
@@ -473,7 +473,7 @@
    ---------------------------
 
    function ${env_getter} (E : Entity) return AST_Envs.Lexical_Env is
-      Self_As_Root : constant ${root_node_type_name} := E.Node;
+      Self_As_Root : constant ${T.root_node.name} := E.Node;
       Self         : constant ${cls.name} :=
          ${cls.internal_conversion(T.root_node, 'Self_As_Root')};
 
@@ -506,7 +506,7 @@
    is
       use AST_Envs;
 
-      Self_As_Root : constant ${root_node_type_name} :=
+      Self_As_Root : constant ${T.root_node.name} :=
          ${T.root_node.internal_conversion(cls, 'Self')};
       Initial_Env  : Lexical_Env := Bound_Env;
 
@@ -538,7 +538,7 @@
          Bound_Env, Root_Env : AST_Envs.Lexical_Env)
       is
          use AST_Envs;
-         Self_As_Root : constant ${root_node_type_name} :=
+         Self_As_Root : constant ${T.root_node.name} :=
             ${T.root_node.internal_conversion(cls, 'Self')};
          Initial_Env  : Lexical_Env := Bound_Env;
       begin

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -152,21 +152,20 @@
       type_name = field.struct.entity.api_name
       ret_type = field.type.entity if field.type.is_ast_node else field.type
       bare_type = field.struct
+
+      node_expr = field.struct.internal_conversion(
+         T.root_node, 'Node.Internal.Node'
+      )
+      field_expr = 'Implementation.{} ({})'.format(field.name, node_expr)
    %>
 
    function ${field.name}
      (Node : ${type_name}'Class) return ${ret_type.api_name}
    is
-      Self   : constant ${bare_type.name} := ${bare_type.internal_conversion(
-         T.root_node, 'Node.Internal.Node')};
-      Result : constant ${field.type.name} := ${(
-          field.type.extract_from_storage_expr(
-              node_expr='Self',
-              base_expr='Self.{}'.format(field.name)
-          )
-      )};
+      Result : ${field.type.name};
    begin
       Check_Safety_Net (Node.Safety_Net);
+      Result := ${field_expr};
       % if field.type.is_ast_node:
          return (Internal   => (${T.root_node.internal_conversion(
                                      field.type, 'Result')},
@@ -178,13 +177,8 @@
    end ${field.name};
 
    % if field.type.is_ast_node:
-      <%
-         node_expr = field.struct.internal_conversion(
-            T.root_node, 'Node.Internal.Node')
-         field_expr = '{}.{}'.format(node_expr, field.name)
-         root_field_expr = T.root_node.internal_conversion(field.type,
-                                                           field_expr)
-      %>
+      <% root_field_expr = T.root_node.internal_conversion(field.type,
+                                                           field_expr) %>
 
       % if field.type.is_bool_node:
          function ${field.name} (Node : ${type_name}'Class) return Boolean is

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -13,7 +13,7 @@
 
 <%def name="public_incomplete_decl(cls)">
    type ${cls.value_type_name()};
-   type ${cls.name} is access all ${cls.value_type_name()}'Class;
+   type ${cls.name} is access all ${cls.value_type_name()};
 
    ${cls.null_constant} : constant ${cls.name} := null;
 
@@ -93,7 +93,7 @@
    <% type_name = field.struct.value_type_name() %>
 
    function ${field.name}
-     (Node : access ${type_name}'Class) return ${field.type.name};
+     (Node : access ${type_name}) return ${field.type.name};
 </%def>
 
 
@@ -101,7 +101,7 @@
    <% type_name = field.struct.value_type_name() %>
 
    function ${field.name}
-     (Node : access ${type_name}'Class) return ${field.type.name}
+     (Node : access ${type_name}) return ${field.type.name}
    is
       <%def name="return_value(node_expr)">
          return ${field.type.extract_from_storage_expr(
@@ -243,10 +243,11 @@
       ext = ctx.ext('nodes', cls.raw_name, 'public_decls')
    %>
 
-   type ${type_name} is ${"abstract" if cls.abstract else ""}
-      new ${cls.base.value_type_name()} with record
-      ${node_fields(cls)}
-   end record;
+   type ${type_name} is record
+      Base : ${cls.base.value_type_name()};
+      ${node_fields(cls, emit_null=False)}
+   end record
+      with Convention => C;
 
    ## Fields initialization helper
    % if cls.has_fields_initializer:
@@ -255,7 +256,7 @@
          parse_fields = [f for f in fields if not f.is_user_field]
       %>
       procedure Initialize_Fields_For_${cls.kwless_raw_name}
-        (Self : access ${cls.value_type_name()}'Class
+        (Self : access ${cls.value_type_name()}
          % for f in parse_fields:
          ; ${f.name} : ${f.type.name}
          % endfor
@@ -280,13 +281,13 @@
    % if cls.env_spec:
 
       function ${cls.name}_Pre_Env_Actions
-        (Self                : access ${type_name}'Class;
+        (Self                : access ${type_name};
          Bound_Env, Root_Env : AST_Envs.Lexical_Env;
          Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env;
 
       % if cls.env_spec.post_actions:
          procedure ${cls.name}_Post_Env_Actions
-           (Self                : access ${type_name}'Class;
+           (Self                : access ${type_name};
             Bound_Env, Root_Env : AST_Envs.Lexical_Env);
       % endif
 
@@ -504,7 +505,7 @@
    % endif
 
    function ${cls.name}_Pre_Env_Actions
-     (Self                : access ${type_name}'Class;
+     (Self                : access ${type_name};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env
    is
@@ -538,7 +539,7 @@
 
    % if cls.env_spec.post_actions:
       procedure ${cls.name}_Post_Env_Actions
-        (Self                : access ${type_name}'Class;
+        (Self                : access ${type_name};
          Bound_Env, Root_Env : AST_Envs.Lexical_Env)
       is
          use AST_Envs;
@@ -574,7 +575,7 @@
          parent_parse_fields = filter_parse_fields(parent_fields)
       %>
       procedure Initialize_Fields_For_${cls.kwless_raw_name}
-        (Self : access ${cls.value_type_name()}'Class
+        (Self : access ${cls.value_type_name()}
          % for f in all_parse_fields:
          ; ${f.name} : ${f.type.name}
          % endfor

--- a/langkit/templates/c_api/astnode_types_ada.mako
+++ b/langkit/templates/c_api/astnode_types_ada.mako
@@ -44,7 +44,7 @@
 
    ${accessor_profile(field)}
    is
-      Unwrapped_Node : constant ${root_node_type_name} := Node.Node;
+      Unwrapped_Node : constant ${T.root_node.name} := Node.Node;
       ## For each input argument, convert the C-level value into an Ada-level
       ## one.
       % for arg in field.arguments:

--- a/langkit/templates/c_api/pkg_main_body_ada.mako
+++ b/langkit/templates/c_api/pkg_main_body_ada.mako
@@ -578,7 +578,7 @@ package body ${ada_lib_name}.Implementation.C is
       Clear_Last_Exception;
 
       declare
-         Result : ${root_node_type_name};
+         Result : ${T.root_node.name};
          Exists : Boolean;
       begin
          if N > unsigned (Natural'Last) then

--- a/langkit/templates/c_api/pkg_main_spec_ada.mako
+++ b/langkit/templates/c_api/pkg_main_spec_ada.mako
@@ -664,9 +664,9 @@ private package ${ada_lib_name}.Implementation.C is
      (${symbol_type}, Symbol_Type);
 
    function Wrap is new Ada.Unchecked_Conversion
-     (${root_node_type_name}, ${node_type});
+     (${T.root_node.name}, ${node_type});
    function Unwrap is new Ada.Unchecked_Conversion
-     (${node_type}, ${root_node_type_name});
+     (${node_type}, ${T.root_node.name});
 
    function Wrap (Token : Token_Reference) return ${token_type};
    function Unwrap (Token : ${token_type}) return Token_Reference;

--- a/langkit/templates/gdb_py.mako
+++ b/langkit/templates/gdb_py.mako
@@ -6,11 +6,14 @@ sys.path.append(${repr(langkit_path)})
 <%
     astnode_names = [node.kwless_raw_name.camel_with_underscores
                      for node in ctx.astnode_types]
+    astnode_kinds = {kind: node.kwless_raw_name.camel_with_underscores
+                     for node, kind in ctx.node_kind_constants.items()}
 %>
 
 import langkit.gdb
 langkit.gdb.setup(
     lib_name=${repr(lib_name)},
     astnode_names=${repr(astnode_names)},
+    astnode_kinds=${repr(astnode_kinds)},
     prefix=${repr(prefix)}
 )

--- a/langkit/templates/list_types_ada.mako
+++ b/langkit/templates/list_types_ada.mako
@@ -34,11 +34,10 @@
    ## Helpers generated for properties code. Used in CollectionGet's and
    ## Map/Quantifier's code.
    function Item
-     (Node : access ${value_type}; Index : Positive)
-      return ${element_type.name};
+     (Node : ${type_name}; Index : Positive) return ${element_type.name};
 
    function Get
-     (Node    : access ${value_type};
+     (Node    : ${type_name};
       Index   : Integer;
       Or_Null : Boolean := False) return ${element_type.name};
    --  When Index is positive, return the Index'th element in T. Otherwise,
@@ -58,7 +57,7 @@
    ---------
 
    function Get
-     (Node    : access ${value_type};
+     (Node    : ${type_name};
       Index   : Integer;
       Or_Null : Boolean := False) return ${element_type.name}
    is
@@ -107,8 +106,7 @@
    ----------
 
    function Item
-     (Node : access ${value_type}; Index : Positive)
-      return ${element_type.name}
+     (Node : ${type_name}; Index : Positive) return ${element_type.name}
    is
       Result : constant ${root_node_type_name} :=
         Child (${T.root_node.internal_conversion(list_type, 'Node')}, Index);

--- a/langkit/templates/list_types_ada.mako
+++ b/langkit/templates/list_types_ada.mako
@@ -27,7 +27,7 @@
    %>
 
    type ${value_type} is record
-      Base : ${generic_list_value_type};
+      Base : ${ctx.generic_list_type.value_type_name()};
    end record
       with Convention => C;
 
@@ -108,7 +108,7 @@
    function Item
      (Node : ${type_name}; Index : Positive) return ${element_type.name}
    is
-      Result : constant ${root_node_type_name} :=
+      Result : constant ${T.root_node.name} :=
         Child (${T.root_node.internal_conversion(list_type, 'Node')}, Index);
    begin
       return ${element_type.internal_conversion(T.root_node, 'Result')};

--- a/langkit/templates/list_types_ada.mako
+++ b/langkit/templates/list_types_ada.mako
@@ -11,7 +11,7 @@
    <% list_type = element_type.list %>
 
    type ${list_type.value_type_name()};
-   type ${list_type.name} is access all ${list_type.value_type_name()}'Class;
+   type ${list_type.name} is access all ${list_type.value_type_name()};
 
    ${list_type.null_constant} : constant ${list_type.name} := null;
 
@@ -26,18 +26,19 @@
       type_name = list_type.name
    %>
 
-   type ${value_type} is
-      ${'abstract' if element_type.has_abstract_list else ''}
-      new ${generic_list_value_type} with null record;
+   type ${value_type} is record
+      Base : ${generic_list_value_type};
+   end record
+      with Convention => C;
 
    ## Helpers generated for properties code. Used in CollectionGet's and
    ## Map/Quantifier's code.
    function Item
-     (Node  : access ${value_type}'Class; Index : Positive)
+     (Node : access ${value_type}; Index : Positive)
       return ${element_type.name};
 
    function Get
-     (Node    : access ${value_type}'Class;
+     (Node    : access ${value_type};
       Index   : Integer;
       Or_Null : Boolean := False) return ${element_type.name};
    --  When Index is positive, return the Index'th element in T. Otherwise,
@@ -57,7 +58,7 @@
    ---------
 
    function Get
-     (Node    : access ${value_type}'Class;
+     (Node    : access ${value_type};
       Index   : Integer;
       Or_Null : Boolean := False) return ${element_type.name}
    is
@@ -106,7 +107,7 @@
    ----------
 
    function Item
-     (Node  : access ${value_type}'Class; Index : Positive)
+     (Node : access ${value_type}; Index : Positive)
       return ${element_type.name}
    is
       Result : constant ${root_node_type_name} :=

--- a/langkit/templates/parsers/list_code_ada.mako
+++ b/langkit/templates/parsers/list_code_ada.mako
@@ -65,7 +65,7 @@ begin
    end if;
 
    declare
-      As_Root_Node    : constant ${root_node_type_name} :=
+      As_Root_Node    : constant ${T.root_node.name} :=
          ${T.root_node.internal_conversion(parser.type, parser.res_var)};
       As_Generic_List : constant ${ctx.generic_list_type.name} :=
          ${ctx.generic_list_type.internal_conversion(T.root_node,

--- a/langkit/templates/parsers/pkg_main_body_ada.mako
+++ b/langkit/templates/parsers/pkg_main_body_ada.mako
@@ -46,7 +46,7 @@ package body ${ada_lib_name}.Parsers is
    pragma Warnings (On, "possible aliasing problem for type");
 
    procedure Initialize_List
-     (Self   : access ${generic_list_value_type};
+     (Self   : ${ctx.generic_list_type.name};
       Parser : Parser_Type;
       Count  : Natural);
    --  Helper for parsers, to initialize the list of children in a freshly
@@ -110,7 +110,7 @@ package body ${ada_lib_name}.Parsers is
    ---------------------
 
    procedure Initialize_List
-     (Self   : access ${generic_list_value_type};
+     (Self   : ${ctx.generic_list_type.name};
       Parser : Parser_Type;
       Count  : Natural) is
    begin

--- a/langkit/templates/parsers/pkg_main_body_ada.mako
+++ b/langkit/templates/parsers/pkg_main_body_ada.mako
@@ -22,9 +22,9 @@ package body ${ada_lib_name}.Parsers is
    --  of node (including lists). Likewise for bump ptr. allocators, except
    --  we need them only for non-abstract AST nodes.
    --
-   --  In the Tagged_Alloc instanciations, there are unchecked conversions to
-   --  wrap System.Address values from a low-level allocator. All read/writes
-   --  for the pointed values are made through values of the same access types
+   --  In the Alloc instanciations, there are unchecked conversions to wrap
+   --  System.Address values from a low-level allocator. All read/writes for
+   --  the pointed values are made through values of the same access types
    --  (i.e. AST node access). Thus, strict aliasing issues should not arise
    --  for these.
    --
@@ -38,15 +38,15 @@ package body ${ada_lib_name}.Parsers is
         (${cls.name}, Token_Index);
 
       % if not cls.abstract:
-         package ${cls.name}_Alloc is
-            new Tagged_Alloc (${cls.value_type_name()});
+         package ${cls.name}_Alloc is new Alloc
+           (${cls.value_type_name()}, ${cls.name});
       % endif
    % endfor
    pragma Warnings (On, "is not referenced");
    pragma Warnings (On, "possible aliasing problem for type");
 
    procedure Initialize_List
-     (Self   : access ${generic_list_value_type}'Class;
+     (Self   : access ${generic_list_value_type};
       Parser : Parser_Type;
       Count  : Natural);
    --  Helper for parsers, to initialize the list of children in a freshly
@@ -110,7 +110,7 @@ package body ${ada_lib_name}.Parsers is
    ---------------------
 
    procedure Initialize_List
-     (Self   : access ${generic_list_value_type}'Class;
+     (Self   : access ${generic_list_value_type};
       Parser : Parser_Type;
       Count  : Natural) is
    begin

--- a/langkit/templates/parsers/pkg_main_body_ada.mako
+++ b/langkit/templates/parsers/pkg_main_body_ada.mako
@@ -209,7 +209,7 @@ package body ${ada_lib_name}.Parsers is
       Check_Complete : Boolean := True;
       Rule           : Grammar_Rule) return Parsed_Node
    is
-      Result : ${root_node_type_name};
+      Result : ${T.root_node.name};
    begin
       case Rule is
       % for name in ctx.grammar.user_defined_rules:

--- a/langkit/templates/parsers/pkg_main_spec_ada.mako
+++ b/langkit/templates/parsers/pkg_main_spec_ada.mako
@@ -39,7 +39,8 @@ private package ${ada_lib_name}.Parsers is
       end case;
    end record;
 
-   type Parsed_Node is access all Implementation.${root_node_value_type};
+   type Parsed_Node is
+      access all Implementation.${T.root_node.value_type_name()};
 
    type Parser_Private_Part is private;
 

--- a/langkit/templates/parsers/transform_code_ada.mako
+++ b/langkit/templates/parsers/transform_code_ada.mako
@@ -53,12 +53,12 @@ if ${parser.pos_var} /= No_Token_Index then
       ## Update Last_Attempted_Child for the created node depending on the
       ## subparsers' results.
       declare
-         N : constant ${root_node_type_name} :=
+         N : constant ${T.root_node.name} :=
             ${T.root_node.internal_conversion(parser.type, parser.res_var)};
       begin
          % for _, subparser, subresult in args:
             declare
-               C : constant ${root_node_type_name} :=
+               C : constant ${T.root_node.name} :=
                   ${T.root_node.internal_conversion(subparser.type,
                                                     subresult)};
             begin

--- a/langkit/templates/parsers/transform_code_ada.mako
+++ b/langkit/templates/parsers/transform_code_ada.mako
@@ -39,16 +39,17 @@ if ${parser.pos_var} /= No_Token_Index then
                             then No_Token_Index
                             else ${parser.pos_var} - 1));
 
-   % if args:
-      ## Initialize children fields in the created node
+   ## Run the kind-specific initializer, if any
+   % if parser.type.has_fields_initializer:
       Initialize_Fields_For_${parser.type.kwless_raw_name}
-        (Self => ${parser.res_var},
-         ${', '.join(
-            '{} => {}'.format(
+        (Self => ${parser.res_var}${''.join(
+            ', {} => {}'.format(
                field.name,
                field.type.internal_conversion(subparser.type, subresult))
             for field, subparser, subresult in args)});
+   % endif
 
+   % if args:
       ## Update Last_Attempted_Child for the created node depending on the
       ## subparsers' results.
       declare

--- a/langkit/templates/pkg_analysis_body_ada.mako
+++ b/langkit/templates/pkg_analysis_body_ada.mako
@@ -984,17 +984,6 @@ package body ${ada_lib_name}.Analysis is
       Result_Status := Traverse (Node, Visit);
    end Traverse;
 
-   -----------------
-   -- Child_Index --
-   -----------------
-
-   function Child_Index (Node : ${root_entity.api_name}'Class) return Natural
-   is
-   begin
-      Check_Safety_Net (Node.Safety_Net);
-      return Child_Index (Node.Internal.Node);
-   end Child_Index;
-
    --------------------------------
    -- Assign_Names_To_Logic_Vars --
    --------------------------------

--- a/langkit/templates/pkg_analysis_body_ada.mako
+++ b/langkit/templates/pkg_analysis_body_ada.mako
@@ -956,7 +956,7 @@ package body ${ada_lib_name}.Analysis is
       -------------
 
       function Wrapper
-        (Node : access ${root_node_value_type}'Class) return Visit_Status
+        (Node : access ${root_node_value_type}) return Visit_Status
       is
          Public_Node : constant ${root_entity.api_name} :=
            Wrap_Node (${root_node_type_name} (Node), Info);
@@ -1110,7 +1110,7 @@ package body ${ada_lib_name}.Analysis is
    function Unwrap_Unit (Unit : Analysis_Unit'Class) return Internal_Unit;
 
    function Wrap_Node
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name};
    function Unwrap_Node
@@ -1158,7 +1158,7 @@ package body ${ada_lib_name}.Analysis is
    ---------------
 
    function Wrap_Node
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name} is
    begin

--- a/langkit/templates/pkg_analysis_body_ada.mako
+++ b/langkit/templates/pkg_analysis_body_ada.mako
@@ -638,7 +638,7 @@ package body ${ada_lib_name}.Analysis is
       function As_${e.element_type.kwless_raw_name}
         (Node : ${root_entity.api_name}'Class) return ${e.api_name}
       is
-         N : constant ${root_node_type_name} := Node.Internal.Node;
+         N : constant ${T.root_node.name} := Node.Internal.Node;
       begin
          if N = null then
             return No_${e.api_name};
@@ -829,7 +829,7 @@ package body ${ada_lib_name}.Analysis is
       Index_In_Bounds : out Boolean;
       Result          : out ${root_entity.api_name})
    is
-      N : ${root_node_type_name};
+      N : ${T.root_node.name};
    begin
       Check_Safety_Net (Node.Safety_Net);
       Get_Child (Node.Internal.Node, Index, Index_In_Bounds, N);
@@ -955,10 +955,10 @@ package body ${ada_lib_name}.Analysis is
       -- Wrapper --
       -------------
 
-      function Wrapper (Node : ${root_node_type_name}) return Visit_Status
+      function Wrapper (Node : ${T.root_node.name}) return Visit_Status
       is
          Public_Node : constant ${root_entity.api_name} :=
-           Wrap_Node (${root_node_type_name} (Node), Info);
+           Wrap_Node (${T.root_node.name} (Node), Info);
       begin
          return Visit (Public_Node);
       end Wrapper;
@@ -1109,11 +1109,11 @@ package body ${ada_lib_name}.Analysis is
    function Unwrap_Unit (Unit : Analysis_Unit'Class) return Internal_Unit;
 
    function Wrap_Node
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name};
    function Unwrap_Node
-     (Node : ${root_entity.api_name}'Class) return ${root_node_type_name};
+     (Node : ${root_entity.api_name}'Class) return ${T.root_node.name};
    function Unwrap_Entity
      (Entity : ${root_entity.api_name}'Class) return ${root_entity.name};
 
@@ -1157,7 +1157,7 @@ package body ${ada_lib_name}.Analysis is
    ---------------
 
    function Wrap_Node
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name} is
    begin
@@ -1182,7 +1182,7 @@ package body ${ada_lib_name}.Analysis is
    -----------------
 
    function Unwrap_Node
-     (Node : ${root_entity.api_name}'Class) return ${root_node_type_name}
+     (Node : ${root_entity.api_name}'Class) return ${T.root_node.name}
    is (Node.Internal.Node);
 
    -------------------

--- a/langkit/templates/pkg_analysis_body_ada.mako
+++ b/langkit/templates/pkg_analysis_body_ada.mako
@@ -955,8 +955,7 @@ package body ${ada_lib_name}.Analysis is
       -- Wrapper --
       -------------
 
-      function Wrapper
-        (Node : access ${root_node_value_type}) return Visit_Status
+      function Wrapper (Node : ${root_node_type_name}) return Visit_Status
       is
          Public_Node : constant ${root_entity.api_name} :=
            Wrap_Node (${root_node_type_name} (Node), Info);
@@ -1110,7 +1109,7 @@ package body ${ada_lib_name}.Analysis is
    function Unwrap_Unit (Unit : Analysis_Unit'Class) return Internal_Unit;
 
    function Wrap_Node
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name};
    function Unwrap_Node
@@ -1158,7 +1157,7 @@ package body ${ada_lib_name}.Analysis is
    ---------------
 
    function Wrap_Node
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name} is
    begin

--- a/langkit/templates/pkg_analysis_spec_ada.mako
+++ b/langkit/templates/pkg_analysis_spec_ada.mako
@@ -517,9 +517,6 @@ package ${ada_lib_name}.Analysis is
    --  This is the same as Traverse function except that no result is returned
    --  i.e. the Traverse function is called and the result is simply discarded.
 
-   function Child_Index (Node : ${root_entity.api_name}'Class) return Natural;
-   --  Return the 0-based index for Node in its parent's children
-
    ----------------------------------------
    -- Source location-related operations --
    ----------------------------------------

--- a/langkit/templates/pkg_analysis_spec_ada.mako
+++ b/langkit/templates/pkg_analysis_spec_ada.mako
@@ -669,7 +669,7 @@ private
    --  helpers at no cost.
 
    Version : String renames ${ada_lib_name}.Version;
-   procedure RN (Node : ${ada_lib_name}.Implementation.${root_node_type_name})
+   procedure RN (Node : ${ada_lib_name}.Implementation.${T.root_node.name})
       renames ${ada_lib_name}.Debug.PN;
 
 end ${ada_lib_name}.Analysis;

--- a/langkit/templates/pkg_converters_spec_ada.mako
+++ b/langkit/templates/pkg_converters_spec_ada.mako
@@ -29,7 +29,7 @@ private package ${ada_lib_name}.Converters is
    Unwrap_Unit : Unit_Unwrapper;
 
    type Node_Wrapper is access function
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name};
    Wrap_Node : Node_Wrapper;

--- a/langkit/templates/pkg_converters_spec_ada.mako
+++ b/langkit/templates/pkg_converters_spec_ada.mako
@@ -29,13 +29,13 @@ private package ${ada_lib_name}.Converters is
    Unwrap_Unit : Unit_Unwrapper;
 
    type Node_Wrapper is access function
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name};
    Wrap_Node : Node_Wrapper;
 
    type Node_Unwrapper is access function
-     (Node : ${root_entity.api_name}'Class) return ${root_node_type_name};
+     (Node : ${root_entity.api_name}'Class) return ${T.root_node.name};
    Unwrap_Node : Node_Unwrapper;
 
    type Entity_Unwrapper is access function

--- a/langkit/templates/pkg_converters_spec_ada.mako
+++ b/langkit/templates/pkg_converters_spec_ada.mako
@@ -29,7 +29,7 @@ private package ${ada_lib_name}.Converters is
    Unwrap_Unit : Unit_Unwrapper;
 
    type Node_Wrapper is access function
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.api_name};
    Wrap_Node : Node_Wrapper;

--- a/langkit/templates/pkg_debug_body_ada.mako
+++ b/langkit/templates/pkg_debug_body_ada.mako
@@ -22,7 +22,7 @@ package body ${ada_lib_name}.Debug is
    -- PN --
    --------
 
-   procedure PN (Node : ${root_node_type_name}) is
+   procedure PN (Node : ${T.root_node.name}) is
    begin
       Put_Line (Image (Short_Text_Image (Node)));
    end PN;
@@ -31,7 +31,7 @@ package body ${ada_lib_name}.Debug is
    -- PT --
    --------
 
-   procedure PT (Node : ${root_node_type_name}) is
+   procedure PT (Node : ${T.root_node.name}) is
    begin
       Print (Node, Show_Slocs => True);
    end PT;
@@ -86,7 +86,7 @@ package body ${ada_lib_name}.Debug is
    -- PRel --
    ----------
 
-   procedure PRel (Rel : Relation; Context_Node : ${root_node_type_name}) is
+   procedure PRel (Rel : Relation; Context_Node : ${T.root_node.name}) is
    begin
       Assign_Names_To_Logic_Vars (Context_Node);
       Print_Relation (Rel, null, False);

--- a/langkit/templates/pkg_debug_spec_ada.mako
+++ b/langkit/templates/pkg_debug_spec_ada.mako
@@ -14,12 +14,12 @@ use ${ada_lib_name}.Implementation;
 
 private package ${ada_lib_name}.Debug is
 
-   procedure PN (Node : ${root_node_type_name});
+   procedure PN (Node : ${T.root_node.name});
    --  "Print Node".  Shortcut for Put_Line (Node.Short_Image). This is useful
    --  because Short_Image takes an implicit accessibility level parameter,
    --  which is not convenient in GDB.
 
-   procedure PT (Node : ${root_node_type_name});
+   procedure PT (Node : ${T.root_node.name});
    --  "Print Tree". Shortcut for Node.Print. This is useful because Print is a
    --  dispatching primitive whereas these are difficult to call from GDB.
    --  Besides, it removes the Level parameter.
@@ -36,7 +36,7 @@ private package ${ada_lib_name}.Debug is
    --  Return whether the text associated to S matches Text. There is a bug in
    --  GDB that makes comparison with "=" always return false.
 
-   procedure PRel (Rel : Relation; Context_Node : ${root_node_type_name});
+   procedure PRel (Rel : Relation; Context_Node : ${T.root_node.name});
    --  "Print Relation". Print Rel as a tree of logic relations
 
 end ${ada_lib_name}.Debug;

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -2587,7 +2587,7 @@ package body ${ada_lib_name}.Implementation is
    -----------------
 
    function Child_Index
-     (Node : access ${root_node_value_type}'Class) return Natural
+     (Node : access ${root_node_value_type}'Class) return Integer
    is
       N : ${root_node_type_name} := null;
    begin

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -140,10 +140,10 @@ package body ${ada_lib_name}.Implementation is
    procedure Destroy (Env : in out Lexical_Env_Access);
 
    function Snaps_At_Start
-     (Self : access ${root_node_value_type}'Class) return Boolean;
+     (Self : access ${root_node_value_type}) return Boolean;
 
    function Snaps_At_End
-     (Self : access ${root_node_value_type}'Class) return Boolean;
+     (Self : access ${root_node_value_type}) return Boolean;
 
    --  Those maps are used to give unique ids to lexical envs while pretty
    --  printing them.
@@ -682,7 +682,7 @@ package body ${ada_lib_name}.Implementation is
 
       procedure Reset_Envs_Caches (Unit : Internal_Unit) is
          procedure Internal
-           (Node : access ${root_node_value_type}'Class) is
+           (Node : access ${root_node_value_type}) is
          begin
             if Node = null then
                return;
@@ -1005,7 +1005,7 @@ package body ${ada_lib_name}.Implementation is
    -------------------
 
    function Is_Token_Node
-     (Node : access ${root_node_value_type}'Class) return Boolean is
+     (Node : access ${root_node_value_type}) return Boolean is
    begin
       return Is_Token_Node (Node.Kind);
    end Is_Token_Node;
@@ -1015,7 +1015,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Is_Synthetic
-     (Node : access ${root_node_value_type}'Class) return Boolean is
+     (Node : access ${root_node_value_type}) return Boolean is
    begin
       return Node.Kind in Synthetic_Nodes;
    end Is_Synthetic;
@@ -1226,7 +1226,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    procedure Initialize
-     (Self              : access ${root_node_value_type}'Class;
+     (Self              : access ${root_node_value_type};
       Kind              : ${root_node_kind_name};
       Unit              : Internal_Unit;
       Token_Start_Index : Token_Index;
@@ -1252,7 +1252,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------------
 
    function Pre_Env_Actions
-     (Self                : access ${root_node_value_type}'Class;
+     (Self                : access ${root_node_value_type};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env
    is
@@ -1296,7 +1296,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    function Get_Symbol
-     (Node : access ${root_node_value_type}'Class) return Symbol_Type is
+     (Node : access ${root_node_value_type}) return Symbol_Type is
    begin
       return Get_Symbol (Token (Node, Node.Token_Start_Index));
    end Get_Symbol;
@@ -1306,7 +1306,7 @@ package body ${ada_lib_name}.Implementation is
    ----------
 
    function Text
-     (Node : access ${root_node_value_type}'Class) return Text_Type
+     (Node : access ${root_node_value_type}) return Text_Type
    is
       Start_T : constant Token_Reference :=
          Token (Node, Node.Token_Start_Index);
@@ -1350,7 +1350,7 @@ package body ${ada_lib_name}.Implementation is
    ----------
 
    function Unit
-     (Node : access ${root_node_value_type}'Class) return Internal_Unit is
+     (Node : access ${root_node_value_type}) return Internal_Unit is
    begin
       return Node.Unit;
    end Unit;
@@ -1373,7 +1373,7 @@ package body ${ada_lib_name}.Implementation is
    -----------------
 
    procedure Set_Parents
-     (Node, Parent : access ${root_node_value_type}'Class)
+     (Node, Parent : access ${root_node_value_type})
    is
    begin
       if Node = null then
@@ -1391,7 +1391,7 @@ package body ${ada_lib_name}.Implementation is
    -- Destroy --
    -------------
 
-   procedure Destroy (Node : access ${root_node_value_type}'Class) is
+   procedure Destroy (Node : access ${root_node_value_type}) is
    begin
       if Node = null then
          return;
@@ -1407,7 +1407,7 @@ package body ${ada_lib_name}.Implementation is
    -- Child --
    -----------
 
-   function Child (Node  : access ${root_node_value_type}'Class;
+   function Child (Node  : access ${root_node_value_type};
                    Index : Positive) return ${root_node_type_name}
    is
       Result          : ${root_node_type_name};
@@ -1422,8 +1422,8 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Traverse
-     (Node  : access ${root_node_value_type}'Class;
-      Visit : access function (Node : access ${root_node_value_type}'Class)
+     (Node  : access ${root_node_value_type};
+      Visit : access function (Node : access ${root_node_value_type})
               return Visit_Status)
      return Visit_Status
    is
@@ -1470,8 +1470,8 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    procedure Traverse
-     (Node  : access ${root_node_value_type}'Class;
-      Visit : access function (Node : access ${root_node_value_type}'Class)
+     (Node  : access ${root_node_value_type};
+      Visit : access function (Node : access ${root_node_value_type})
                                return Visit_Status)
    is
       Result_Status : Visit_Status;
@@ -1485,21 +1485,21 @@ package body ${ada_lib_name}.Implementation is
    ------------------------
 
    function Traverse_With_Data
-     (Node  : access ${root_node_value_type}'Class;
-      Visit : access function (Node : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
+      Visit : access function (Node : access ${root_node_value_type};
                                Data : in out Data_Type)
                                return Visit_Status;
       Data  : in out Data_Type)
       return Visit_Status
    is
-      function Helper (Node : access ${root_node_value_type}'Class)
+      function Helper (Node : access ${root_node_value_type})
                        return Visit_Status;
 
       ------------
       -- Helper --
       ------------
 
-      function Helper (Node : access ${root_node_value_type}'Class)
+      function Helper (Node : access ${root_node_value_type})
                        return Visit_Status
       is
       begin
@@ -1525,7 +1525,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    function Sloc_Range
-     (Node : access ${root_node_value_type}'Class) return Source_Location_Range
+     (Node : access ${root_node_value_type}) return Source_Location_Range
    is
       type Token_Anchor is (T_Start, T_End);
       type Token_Pos is record
@@ -1578,7 +1578,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Lookup
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Sloc : Source_Location) return ${root_node_type_name}
    is
       Position : Relative_Position;
@@ -1649,7 +1649,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Compare
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Sloc : Source_Location) return Relative_Position is
    begin
       return Compare (Sloc_Range (Node), Sloc);
@@ -1679,7 +1679,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Compare
-     (Left, Right : access ${root_node_value_type}'Class;
+     (Left, Right : access ${root_node_value_type};
       Relation    : Comparison_Relation) return Boolean
    is
       LS, RS : Source_Location;
@@ -1702,7 +1702,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Children
-     (Node : access ${root_node_value_type}'Class)
+     (Node : access ${root_node_value_type})
      return ${root_node_array.array_type_name}
    is
       First : constant Integer := ${root_node_array.index_type()}'First;
@@ -1717,7 +1717,7 @@ package body ${ada_lib_name}.Implementation is
    end Children;
 
    function Children
-     (Node : access ${root_node_value_type}'Class)
+     (Node : access ${root_node_value_type})
      return ${root_node_array.name}
    is
       C : ${root_node_array.array_type_name} := Children (Node);
@@ -1734,7 +1734,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    procedure PP_Trivia
-     (Node        : access ${root_node_value_type}'Class;
+     (Node        : access ${root_node_value_type};
       Line_Prefix : String := "")
    is
       Children_Prefix : constant String := Line_Prefix & "|  ";
@@ -1755,14 +1755,14 @@ package body ${ada_lib_name}.Implementation is
    --------------------------
 
    function Populate_Lexical_Env
-     (Node : access ${root_node_value_type}'Class) return Boolean
+     (Node : access ${root_node_value_type}) return Boolean
    is
 
       Context  : constant Internal_Context := Node.Unit.Context;
       Root_Env : constant Lexical_Env := Context.Root_Scope;
 
       function Populate_Internal
-        (Node      : access ${root_node_value_type}'Class;
+        (Node      : access ${root_node_value_type};
          Bound_Env : Lexical_Env) return Boolean;
       --  Do the lexical env population on Node and recurse on its children
 
@@ -1771,7 +1771,7 @@ package body ${ada_lib_name}.Implementation is
       -----------------------
 
       function Populate_Internal
-        (Node      : access ${root_node_value_type}'Class;
+        (Node      : access ${root_node_value_type};
          Bound_Env : Lexical_Env) return Boolean
       is
          Result      : Boolean := False;
@@ -1913,10 +1913,10 @@ package body ${ada_lib_name}.Implementation is
    -- Hash --
    ----------
 
-   function Hash (Node : access ${root_node_value_type}'Class) return Hash_Type
+   function Hash (Node : access ${root_node_value_type}) return Hash_Type
    is
       function H is new Hash_Access
-        (${root_node_value_type}'Class, ${root_node_type_name});
+        (${root_node_value_type}, ${root_node_type_name});
    begin
       return H (Node);
    end Hash;
@@ -2139,7 +2139,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    function Short_Text_Image
-     (Self : access ${root_node_value_type}'Class) return Text_Type is
+     (Self : access ${root_node_value_type}) return Text_Type is
    begin
       if Self = null then
          return "None";
@@ -2167,7 +2167,7 @@ package body ${ada_lib_name}.Implementation is
    --------------------
 
    function Snaps_At_Start
-     (Self : access ${root_node_value_type}'Class) return Boolean is
+     (Self : access ${root_node_value_type}) return Boolean is
    begin
       <%self:case_dispatch pred="${lambda n: n.snaps_at_start}">
       <%def name="action(node)">
@@ -2184,7 +2184,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Snaps_At_End
-     (Self : access ${root_node_value_type}'Class) return Boolean is
+     (Self : access ${root_node_value_type}) return Boolean is
    begin
       <%self:case_dispatch pred="${lambda n: n.snaps_at_end}">
       <%def name="action(node)">
@@ -2201,7 +2201,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Parents
-     (Node         : access ${root_node_value_type}'Class;
+     (Node         : access ${root_node_value_type};
       Include_Self : Boolean := True)
       return ${root_node_array.name}
    is
@@ -2233,7 +2233,7 @@ package body ${ada_lib_name}.Implementation is
    -----------------------
 
    function First_Child_Index
-     (Node : access ${root_node_value_type}'Class) return Natural
+     (Node : access ${root_node_value_type}) return Natural
    is (1);
 
    ----------------------
@@ -2241,7 +2241,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    function Last_Child_Index
-     (Node : access ${root_node_value_type}'Class) return Natural
+     (Node : access ${root_node_value_type}) return Natural
    is (Children_Count (Node));
 
    ---------------
@@ -2249,7 +2249,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    procedure Get_Child
-     (Node            : access ${root_node_value_type}'Class;
+     (Node            : access ${root_node_value_type};
       Index           : Positive;
       Index_In_Bounds : out Boolean;
       Result          : out ${root_node_type_name})
@@ -2323,7 +2323,7 @@ package body ${ada_lib_name}.Implementation is
    -----------
 
    procedure Print
-     (Node        : access ${root_node_value_type}'Class;
+     (Node        : access ${root_node_value_type};
       Show_Slocs  : Boolean;
       Line_Prefix : String := "")
    is
@@ -2404,8 +2404,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Parent
-     (Node : access ${root_node_value_type}'Class) return ${root_node_type_name}
-   is
+     (Node : access ${root_node_value_type}) return ${root_node_type_name} is
    begin
       return Node.Parent;
    end Parent;
@@ -2415,7 +2414,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Stored_Token
-     (Node  : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
       Token : Token_Reference) return Token_Index
    is
       Index : constant Token_Or_Trivia_Index := Get_Token_Index (Token);
@@ -2437,7 +2436,7 @@ package body ${ada_lib_name}.Implementation is
    --------------------------
 
    function Children_With_Trivia
-     (Node : access ${root_node_value_type}'Class) return Bare_Children_Array
+     (Node : access ${root_node_value_type}) return Bare_Children_Array
    is
       package Children_Vectors is new Ada.Containers.Vectors
         (Positive, Bare_Child_Record);
@@ -2451,7 +2450,7 @@ package body ${ada_lib_name}.Implementation is
       --  the returned vector.
 
       function Filter_Children
-        (Parent : access ${root_node_value_type}'Class)
+        (Parent : access ${root_node_value_type})
          return ${root_node_array.array_type_name};
       --  Return an array for all children in Parent that are not null and that
       --  aren't ghost nodes.
@@ -2476,7 +2475,7 @@ package body ${ada_lib_name}.Implementation is
       ---------------------
 
       function Filter_Children
-        (Parent : access ${root_node_value_type}'Class)
+        (Parent : access ${root_node_value_type})
          return ${root_node_array.array_type_name}
       is
          Children : constant ${root_node_array.array_type_name} :=
@@ -2530,7 +2529,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Is_Ghost
-     (Node : access ${root_node_value_type}'Class) return Boolean
+     (Node : access ${root_node_value_type}) return Boolean
    is (Node.Token_End_Index = No_Token_Index);
 
    -------------------
@@ -2538,7 +2537,7 @@ package body ${ada_lib_name}.Implementation is
    -------------------
 
    function Is_Incomplete
-     (Node : access ${root_node_value_type}'Class) return Boolean
+     (Node : access ${root_node_value_type}) return Boolean
    is
       LGC : ${root_node_type_name};
    begin
@@ -2557,7 +2556,7 @@ package body ${ada_lib_name}.Implementation is
    -----------------
 
    function Token_Start
-     (Node : access ${root_node_value_type}'Class) return Token_Reference
+     (Node : access ${root_node_value_type}) return Token_Reference
    is (Token (Node, Node.Token_Start_Index));
 
    ---------------
@@ -2565,7 +2564,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    function Token_End
-     (Node : access ${root_node_value_type}'Class) return Token_Reference
+     (Node : access ${root_node_value_type}) return Token_Reference
    is
      (if Node.Token_End_Index = No_Token_Index
       then Token_Start (Node)
@@ -2576,7 +2575,7 @@ package body ${ada_lib_name}.Implementation is
    -----------
 
    function Token
-     (Node  : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
       Index : Token_Index) return Token_Reference
    is
      (Wrap_Token_Reference (Token_Data (Node.Unit), (Index, No_Token_Index)));
@@ -2586,15 +2585,14 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Is_Null
-     (Node : access ${root_node_value_type}'Class) return Boolean
+     (Node : access ${root_node_value_type}) return Boolean
    is (Node = null);
 
    -----------------
    -- Child_Index --
    -----------------
 
-   function Child_Index
-     (Node : access ${root_node_value_type}'Class) return Integer
+   function Child_Index (Node : access ${root_node_value_type}) return Integer
    is
       N : ${root_node_type_name} := null;
    begin
@@ -2622,7 +2620,7 @@ package body ${ada_lib_name}.Implementation is
    -------------------
 
    function Fetch_Sibling
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name};
       Offset : Integer) return ${root_entity.name}
    is
@@ -2647,7 +2645,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    function Previous_Sibling
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2659,7 +2657,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Next_Sibling
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2747,7 +2745,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Children_Env
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return Lexical_Env
    is (Rebind_Env (Node.Self_Env, E_Info));
@@ -2757,7 +2755,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Node_Env
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return Lexical_Env
    is
@@ -2814,7 +2812,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Parent
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2827,7 +2825,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Parents
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.array.name}
    is
@@ -2848,7 +2846,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Children
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.array.name}
    is
@@ -2887,11 +2885,11 @@ package body ${ada_lib_name}.Implementation is
    --------------------------------
 
    procedure Assign_Names_To_Logic_Vars
-     (Node : access ${root_node_value_type}'Class)
+     (Node : access ${root_node_value_type})
    is
 
       procedure Assign
-        (Node  : access ${root_node_value_type}'Class;
+        (Node  : access ${root_node_value_type};
          LV    : in out Logic_Var_Record;
          Field : String);
       --  Assign a name to the LV logic variable. Node must be the node that
@@ -2903,7 +2901,7 @@ package body ${ada_lib_name}.Implementation is
       ------------
 
       procedure Assign
-        (Node  : access ${root_node_value_type}'Class;
+        (Node  : access ${root_node_value_type};
          LV    : in out Logic_Var_Record;
          Field : String) is
       begin
@@ -3024,7 +3022,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Length
-     (Node : access ${generic_list_value_type}'Class) return Natural
+     (Node : access ${generic_list_value_type}) return Natural
    is (Children_Count
          (${T.root_node.internal_conversion(ctx.generic_list_type, 'Node')}));
 
@@ -3169,7 +3167,7 @@ package body ${ada_lib_name}.Implementation is
 
    procedure Destroy_Synthetic_Node (Node : in out ${root_node_type_name}) is
       procedure Free is new Ada.Unchecked_Deallocation
-        (${root_node_value_type}'Class, ${root_node_type_name});
+        (${root_node_value_type}, ${root_node_type_name});
    begin
       --  Don't call Node.Destroy, as Node's children may be gone already: they
       --  have their own destructor and there is no specified order for the
@@ -3192,7 +3190,7 @@ package body ${ada_lib_name}.Implementation is
       -----------------
 
       function Trace_Image
-        (Node       : access ${root_node_value_type}'Class;
+        (Node       : access ${root_node_value_type};
          Decoration : Boolean := True) return String is
       begin
          if Node = null then
@@ -3221,8 +3219,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    function Kind_Name
-     (Node : access ${root_node_value_type}'Class) return String
-   is
+     (Node : access ${root_node_value_type}) return String is
    begin
       return To_String (Kind_Names (Node.Kind));
    end Kind_Name;
@@ -3232,7 +3229,7 @@ package body ${ada_lib_name}.Implementation is
    --------------------
 
    function Children_Count
-     (Node : access ${root_node_value_type}'Class) return Natural
+     (Node : access ${root_node_value_type}) return Natural
    is
       C : Integer := Kind_To_Node_Children_Count (Node.Kind);
    begin
@@ -3248,7 +3245,7 @@ package body ${ada_lib_name}.Implementation is
    -- Reset_Logic_Vars --
    ----------------------
 
-   procedure Reset_Logic_Vars (Node : access ${root_node_value_type}'Class) is
+   procedure Reset_Logic_Vars (Node : access ${root_node_value_type}) is
 
       procedure Reset (LV : in out Logic_Var_Record);
       --  Reset the LV logic variable, clearing the value it stores
@@ -3418,7 +3415,7 @@ package body ${ada_lib_name}.Implementation is
      (Unit : Internal_Unit; Node : ${root_node_type_name})
    is
       procedure Helper is new Register_Destroyable_Gen
-        (${root_node_value_type}'Class,
+        (${root_node_value_type},
          ${root_node_type_name},
          Destroy_Synthetic_Node);
    begin
@@ -3455,16 +3452,16 @@ package body ${ada_lib_name}.Implementation is
    procedure Reset_Envs (Unit : Internal_Unit) is
 
       procedure Deactivate_Refd_Envs
-        (Node : access ${root_node_value_type}'Class);
+        (Node : access ${root_node_value_type});
       procedure Recompute_Refd_Envs
-        (Node : access ${root_node_value_type}'Class);
+        (Node : access ${root_node_value_type});
 
       --------------------------
       -- Deactivate_Refd_Envs --
       --------------------------
 
       procedure Deactivate_Refd_Envs
-        (Node : access ${root_node_value_type}'Class) is
+        (Node : access ${root_node_value_type}) is
       begin
          if Node = null then
             return;
@@ -3481,7 +3478,7 @@ package body ${ada_lib_name}.Implementation is
       -------------------------
 
       procedure Recompute_Refd_Envs
-        (Node : access ${root_node_value_type}'Class) is
+        (Node : access ${root_node_value_type}) is
       begin
          if Node = null then
             return;
@@ -3911,8 +3908,7 @@ package body ${ada_lib_name}.Implementation is
    -- Reroot_Foreign_Nodes --
    --------------------------
 
-   procedure Reroot_Foreign_Node (Node : access ${root_node_value_type}'Class)
-   is
+   procedure Reroot_Foreign_Node (Node : access ${root_node_value_type}) is
       Unit : constant Internal_Unit := Node.Unit;
    begin
 
@@ -3951,7 +3947,7 @@ package body ${ada_lib_name}.Implementation is
    ----------
 
    function Text
-     (Node : access ${root_node_value_type}'Class) return ${T.String.name}
+     (Node : access ${root_node_value_type}) return ${T.String.name}
    is
       T      : constant Text_Type := Text (Node);
       Result : constant ${T.String.name} :=

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -1152,10 +1152,10 @@ package body ${ada_lib_name}.Implementation is
          % endif
 
          --  Add the element to the environment
-         Add (Self  => Dest_Env,
-              Key   => Mapping.Key,
-              Value => Mapping.Val,
-              MD    => MD,
+         Add (Self     => Dest_Env,
+              Key      => Mapping.Key,
+              Value    => Mapping.Val,
+              MD       => MD,
               Resolver => Resolver);
 
          --  If we're adding the element to an environment that belongs to a

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -2148,7 +2148,8 @@ package body ${ada_lib_name}.Implementation is
       <%self:case_dispatch
          pred="${lambda n: n.annotations.custom_short_image}">
       <%def name="action(node)">
-         return ${node.name}_Short_Image (${node.name} (Self));
+         return ${node.name}_Short_Image
+           (${node.internal_conversion(T.root_node, 'Self')});
       </%def>
       <%def name="default()">
          return "<" & To_Text (Kind_Name (Self))
@@ -2355,7 +2356,8 @@ package body ${ada_lib_name}.Implementation is
          if K in ${ctx.generic_list_type.ada_kind_range_name} then
             declare
                List : constant ${ctx.generic_list_type.name} :=
-                  ${ctx.generic_list_type.name} (Node);
+                  ${ctx.generic_list_type.internal_conversion(T.root_node,
+                                                              'Node')};
             begin
                if List.Count = 0 then
                   Put_Line (": <empty list>");
@@ -2915,8 +2917,12 @@ package body ${ada_lib_name}.Implementation is
       <%
           def get_actions(astnode, node_expr):
               return '\n'.join(
-                  'Assign ({node}, {node}.{field}, "{field}");'.format(
-                     node=node_expr,
+                  'Assign ({root_node}, {field_node}.{field}, "{field}");'
+                  .format(
+                     root_node=T.root_node.internal_conversion(
+                        astnode, node_expr),
+                     field_node=field.struct.internal_conversion(
+                        astnode, node_expr),
                      field=field.name
                   )
                   for field in astnode.get_user_fields(

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -1837,7 +1837,7 @@ package body ${ada_lib_name}.Implementation is
          --  this node.
          declare
             PLE_Unit_Root : constant ${ctx.ple_unit_root.name} :=
-               ${ctx.ple_unit_root.name} (Node);
+               ${ctx.ple_unit_root.internal_conversion(T.root_node, 'Node')};
          begin
             if PLE_Unit_Root.Is_Env_Populated then
                return False;

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -1243,6 +1243,8 @@ package body ${ada_lib_name}.Implementation is
 
       Self.Self_Env := Self_Env;
       Self.Last_Attempted_Child := -1;
+
+      ${astnode_types.init_user_fields(T.root_node, 'Self')}
    end Initialize;
 
    ---------------------

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -139,11 +139,8 @@ package body ${ada_lib_name}.Implementation is
 
    procedure Destroy (Env : in out Lexical_Env_Access);
 
-   function Snaps_At_Start
-     (Self : access ${root_node_value_type}) return Boolean;
-
-   function Snaps_At_End
-     (Self : access ${root_node_value_type}) return Boolean;
+   function Snaps_At_Start (Self : ${root_node_type_name}) return Boolean;
+   function Snaps_At_End (Self : ${root_node_type_name}) return Boolean;
 
    --  Those maps are used to give unique ids to lexical envs while pretty
    --  printing them.
@@ -681,8 +678,7 @@ package body ${ada_lib_name}.Implementation is
          Unit.Context.In_Populate_Lexical_Env;
 
       procedure Reset_Envs_Caches (Unit : Internal_Unit) is
-         procedure Internal
-           (Node : access ${root_node_value_type}) is
+         procedure Internal (Node : ${root_node_type_name}) is
          begin
             if Node = null then
                return;
@@ -1004,8 +1000,7 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Token_Node --
    -------------------
 
-   function Is_Token_Node
-     (Node : access ${root_node_value_type}) return Boolean is
+   function Is_Token_Node (Node : ${root_node_type_name}) return Boolean is
    begin
       return Is_Token_Node (Node.Kind);
    end Is_Token_Node;
@@ -1014,8 +1009,7 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Synthetic --
    ------------------
 
-   function Is_Synthetic
-     (Node : access ${root_node_value_type}) return Boolean is
+   function Is_Synthetic (Node : ${root_node_type_name}) return Boolean is
    begin
       return Node.Kind in Synthetic_Nodes;
    end Is_Synthetic;
@@ -1226,7 +1220,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    procedure Initialize
-     (Self              : access ${root_node_value_type};
+     (Self              : ${root_node_type_name};
       Kind              : ${root_node_kind_name};
       Unit              : Internal_Unit;
       Token_Start_Index : Token_Index;
@@ -1252,7 +1246,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------------
 
    function Pre_Env_Actions
-     (Self                : access ${root_node_value_type};
+     (Self                : ${root_node_type_name};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env
    is
@@ -1274,7 +1268,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    procedure Post_Env_Actions
-     (Self                : access ${root_node_value_type};
+     (Self                : ${root_node_type_name};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env) is
    begin
       <%self:case_dispatch pred="${lambda n: n.env_spec}">
@@ -1296,7 +1290,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    function Get_Symbol
-     (Node : access ${root_node_value_type}) return Symbol_Type is
+     (Node : ${root_node_type_name}) return Symbol_Type is
    begin
       return Get_Symbol (Token (Node, Node.Token_Start_Index));
    end Get_Symbol;
@@ -1306,7 +1300,7 @@ package body ${ada_lib_name}.Implementation is
    ----------
 
    function Text
-     (Node : access ${root_node_value_type}) return Text_Type
+     (Node : ${root_node_type_name}) return Text_Type
    is
       Start_T : constant Token_Reference :=
          Token (Node, Node.Token_Start_Index);
@@ -1349,8 +1343,7 @@ package body ${ada_lib_name}.Implementation is
    -- Unit --
    ----------
 
-   function Unit
-     (Node : access ${root_node_value_type}) return Internal_Unit is
+   function Unit (Node : ${root_node_type_name}) return Internal_Unit is
    begin
       return Node.Unit;
    end Unit;
@@ -1373,7 +1366,7 @@ package body ${ada_lib_name}.Implementation is
    -----------------
 
    procedure Set_Parents
-     (Node, Parent : access ${root_node_value_type})
+     (Node, Parent : ${root_node_type_name})
    is
    begin
       if Node = null then
@@ -1391,7 +1384,7 @@ package body ${ada_lib_name}.Implementation is
    -- Destroy --
    -------------
 
-   procedure Destroy (Node : access ${root_node_value_type}) is
+   procedure Destroy (Node : ${root_node_type_name}) is
    begin
       if Node = null then
          return;
@@ -1407,7 +1400,7 @@ package body ${ada_lib_name}.Implementation is
    -- Child --
    -----------
 
-   function Child (Node  : access ${root_node_value_type};
+   function Child (Node  : ${root_node_type_name};
                    Index : Positive) return ${root_node_type_name}
    is
       Result          : ${root_node_type_name};
@@ -1422,8 +1415,8 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Traverse
-     (Node  : access ${root_node_value_type};
-      Visit : access function (Node : access ${root_node_value_type})
+     (Node  : ${root_node_type_name};
+      Visit : access function (Node : ${root_node_type_name})
               return Visit_Status)
      return Visit_Status
    is
@@ -1470,8 +1463,8 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    procedure Traverse
-     (Node  : access ${root_node_value_type};
-      Visit : access function (Node : access ${root_node_value_type})
+     (Node  : ${root_node_type_name};
+      Visit : access function (Node : ${root_node_type_name})
                                return Visit_Status)
    is
       Result_Status : Visit_Status;
@@ -1485,23 +1478,20 @@ package body ${ada_lib_name}.Implementation is
    ------------------------
 
    function Traverse_With_Data
-     (Node  : access ${root_node_value_type};
-      Visit : access function (Node : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
+      Visit : access function (Node : ${root_node_type_name};
                                Data : in out Data_Type)
                                return Visit_Status;
       Data  : in out Data_Type)
       return Visit_Status
    is
-      function Helper (Node : access ${root_node_value_type})
-                       return Visit_Status;
+      function Helper (Node : ${root_node_type_name}) return Visit_Status;
 
       ------------
       -- Helper --
       ------------
 
-      function Helper (Node : access ${root_node_value_type})
-                       return Visit_Status
-      is
+      function Helper (Node : ${root_node_type_name}) return Visit_Status is
       begin
          return Visit (Node, Data);
       end Helper;
@@ -1525,7 +1515,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    function Sloc_Range
-     (Node : access ${root_node_value_type}) return Source_Location_Range
+     (Node : ${root_node_type_name}) return Source_Location_Range
    is
       type Token_Anchor is (T_Start, T_End);
       type Token_Pos is record
@@ -1578,7 +1568,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Lookup
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Sloc : Source_Location) return ${root_node_type_name}
    is
       Position : Relative_Position;
@@ -1649,7 +1639,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Compare
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Sloc : Source_Location) return Relative_Position is
    begin
       return Compare (Sloc_Range (Node), Sloc);
@@ -1679,7 +1669,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Compare
-     (Left, Right : access ${root_node_value_type};
+     (Left, Right : ${root_node_type_name};
       Relation    : Comparison_Relation) return Boolean
    is
       LS, RS : Source_Location;
@@ -1702,8 +1692,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Children
-     (Node : access ${root_node_value_type})
-     return ${root_node_array.array_type_name}
+     (Node : ${root_node_type_name}) return ${root_node_array.array_type_name}
    is
       First : constant Integer := ${root_node_array.index_type()}'First;
       Last  : constant Integer := First + Children_Count (Node) - 1;
@@ -1717,8 +1706,7 @@ package body ${ada_lib_name}.Implementation is
    end Children;
 
    function Children
-     (Node : access ${root_node_value_type})
-     return ${root_node_array.name}
+     (Node : ${root_node_type_name}) return ${root_node_array.name}
    is
       C : ${root_node_array.array_type_name} := Children (Node);
    begin
@@ -1734,7 +1722,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    procedure PP_Trivia
-     (Node        : access ${root_node_value_type};
+     (Node        : ${root_node_type_name};
       Line_Prefix : String := "")
    is
       Children_Prefix : constant String := Line_Prefix & "|  ";
@@ -1754,15 +1742,14 @@ package body ${ada_lib_name}.Implementation is
    -- Populate_Lexical_Env --
    --------------------------
 
-   function Populate_Lexical_Env
-     (Node : access ${root_node_value_type}) return Boolean
+   function Populate_Lexical_Env (Node : ${root_node_type_name}) return Boolean
    is
 
       Context  : constant Internal_Context := Node.Unit.Context;
       Root_Env : constant Lexical_Env := Context.Root_Scope;
 
       function Populate_Internal
-        (Node      : access ${root_node_value_type};
+        (Node      : ${root_node_type_name};
          Bound_Env : Lexical_Env) return Boolean;
       --  Do the lexical env population on Node and recurse on its children
 
@@ -1771,7 +1758,7 @@ package body ${ada_lib_name}.Implementation is
       -----------------------
 
       function Populate_Internal
-        (Node      : access ${root_node_value_type};
+        (Node      : ${root_node_type_name};
          Bound_Env : Lexical_Env) return Boolean
       is
          Result      : Boolean := False;
@@ -1913,7 +1900,7 @@ package body ${ada_lib_name}.Implementation is
    -- Hash --
    ----------
 
-   function Hash (Node : access ${root_node_value_type}) return Hash_Type
+   function Hash (Node : ${root_node_type_name}) return Hash_Type
    is
       function H is new Hash_Access
         (${root_node_value_type}, ${root_node_type_name});
@@ -2138,8 +2125,8 @@ package body ${ada_lib_name}.Implementation is
    -- Short_Text_Image --
    ----------------------
 
-   function Short_Text_Image
-     (Self : access ${root_node_value_type}) return Text_Type is
+   function Short_Text_Image (Self : ${root_node_type_name}) return Text_Type
+   is
    begin
       if Self = null then
          return "None";
@@ -2166,8 +2153,7 @@ package body ${ada_lib_name}.Implementation is
    -- Snaps_At_Start --
    --------------------
 
-   function Snaps_At_Start
-     (Self : access ${root_node_value_type}) return Boolean is
+   function Snaps_At_Start (Self : ${root_node_type_name}) return Boolean is
    begin
       <%self:case_dispatch pred="${lambda n: n.snaps_at_start}">
       <%def name="action(node)">
@@ -2183,8 +2169,7 @@ package body ${ada_lib_name}.Implementation is
    -- Snaps_At_End --
    ------------------
 
-   function Snaps_At_End
-     (Self : access ${root_node_value_type}) return Boolean is
+   function Snaps_At_End (Self : ${root_node_type_name}) return Boolean is
    begin
       <%self:case_dispatch pred="${lambda n: n.snaps_at_end}">
       <%def name="action(node)">
@@ -2201,7 +2186,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Parents
-     (Node         : access ${root_node_value_type};
+     (Node         : ${root_node_type_name};
       Include_Self : Boolean := True)
       return ${root_node_array.name}
    is
@@ -2232,16 +2217,14 @@ package body ${ada_lib_name}.Implementation is
    -- First_Child_Index --
    -----------------------
 
-   function First_Child_Index
-     (Node : access ${root_node_value_type}) return Natural
+   function First_Child_Index (Node : ${root_node_type_name}) return Natural
    is (1);
 
    ----------------------
    -- Last_Child_Index --
    ----------------------
 
-   function Last_Child_Index
-     (Node : access ${root_node_value_type}) return Natural
+   function Last_Child_Index (Node : ${root_node_type_name}) return Natural
    is (Children_Count (Node));
 
    ---------------
@@ -2249,7 +2232,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    procedure Get_Child
-     (Node            : access ${root_node_value_type};
+     (Node            : ${root_node_type_name};
       Index           : Positive;
       Index_In_Bounds : out Boolean;
       Result          : out ${root_node_type_name})
@@ -2323,7 +2306,7 @@ package body ${ada_lib_name}.Implementation is
    -----------
 
    procedure Print
-     (Node        : access ${root_node_value_type};
+     (Node        : ${root_node_type_name};
       Show_Slocs  : Boolean;
       Line_Prefix : String := "")
    is
@@ -2404,7 +2387,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Parent
-     (Node : access ${root_node_value_type}) return ${root_node_type_name} is
+     (Node : ${root_node_type_name}) return ${root_node_type_name} is
    begin
       return Node.Parent;
    end Parent;
@@ -2414,7 +2397,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Stored_Token
-     (Node  : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
       Token : Token_Reference) return Token_Index
    is
       Index : constant Token_Or_Trivia_Index := Get_Token_Index (Token);
@@ -2436,7 +2419,7 @@ package body ${ada_lib_name}.Implementation is
    --------------------------
 
    function Children_With_Trivia
-     (Node : access ${root_node_value_type}) return Bare_Children_Array
+     (Node : ${root_node_type_name}) return Bare_Children_Array
    is
       package Children_Vectors is new Ada.Containers.Vectors
         (Positive, Bare_Child_Record);
@@ -2450,7 +2433,7 @@ package body ${ada_lib_name}.Implementation is
       --  the returned vector.
 
       function Filter_Children
-        (Parent : access ${root_node_value_type})
+        (Parent : ${root_node_type_name})
          return ${root_node_array.array_type_name};
       --  Return an array for all children in Parent that are not null and that
       --  aren't ghost nodes.
@@ -2475,7 +2458,7 @@ package body ${ada_lib_name}.Implementation is
       ---------------------
 
       function Filter_Children
-        (Parent : access ${root_node_value_type})
+        (Parent : ${root_node_type_name})
          return ${root_node_array.array_type_name}
       is
          Children : constant ${root_node_array.array_type_name} :=
@@ -2528,16 +2511,14 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Ghost --
    --------------
 
-   function Is_Ghost
-     (Node : access ${root_node_value_type}) return Boolean
+   function Is_Ghost (Node : ${root_node_type_name}) return Boolean
    is (Node.Token_End_Index = No_Token_Index);
 
    -------------------
    -- Is_Incomplete --
    -------------------
 
-   function Is_Incomplete
-     (Node : access ${root_node_value_type}) return Boolean
+   function Is_Incomplete (Node : ${root_node_type_name}) return Boolean
    is
       LGC : ${root_node_type_name};
    begin
@@ -2555,16 +2536,14 @@ package body ${ada_lib_name}.Implementation is
    -- Token_Start --
    -----------------
 
-   function Token_Start
-     (Node : access ${root_node_value_type}) return Token_Reference
+   function Token_Start (Node : ${root_node_type_name}) return Token_Reference
    is (Token (Node, Node.Token_Start_Index));
 
    ---------------
    -- Token_End --
    ---------------
 
-   function Token_End
-     (Node : access ${root_node_value_type}) return Token_Reference
+   function Token_End (Node : ${root_node_type_name}) return Token_Reference
    is
      (if Node.Token_End_Index = No_Token_Index
       then Token_Start (Node)
@@ -2575,7 +2554,7 @@ package body ${ada_lib_name}.Implementation is
    -----------
 
    function Token
-     (Node  : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
       Index : Token_Index) return Token_Reference
    is
      (Wrap_Token_Reference (Token_Data (Node.Unit), (Index, No_Token_Index)));
@@ -2584,15 +2563,14 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Null --
    -------------
 
-   function Is_Null
-     (Node : access ${root_node_value_type}) return Boolean
+   function Is_Null (Node : ${root_node_type_name}) return Boolean
    is (Node = null);
 
    -----------------
    -- Child_Index --
    -----------------
 
-   function Child_Index (Node : access ${root_node_value_type}) return Integer
+   function Child_Index (Node : ${root_node_type_name}) return Integer
    is
       N : ${root_node_type_name} := null;
    begin
@@ -2620,7 +2598,7 @@ package body ${ada_lib_name}.Implementation is
    -------------------
 
    function Fetch_Sibling
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name};
       Offset : Integer) return ${root_entity.name}
    is
@@ -2645,7 +2623,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    function Previous_Sibling
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2657,7 +2635,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Next_Sibling
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2745,7 +2723,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Children_Env
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return Lexical_Env
    is (Rebind_Env (Node.Self_Env, E_Info));
@@ -2755,7 +2733,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Node_Env
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return Lexical_Env
    is
@@ -2812,7 +2790,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Parent
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2825,7 +2803,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Parents
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.array.name}
    is
@@ -2846,7 +2824,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Children
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.array.name}
    is
@@ -2884,12 +2862,10 @@ package body ${ada_lib_name}.Implementation is
    -- Assign_Names_To_Logic_Vars --
    --------------------------------
 
-   procedure Assign_Names_To_Logic_Vars
-     (Node : access ${root_node_value_type})
-   is
+   procedure Assign_Names_To_Logic_Vars (Node : ${root_node_type_name}) is
 
       procedure Assign
-        (Node  : access ${root_node_value_type};
+        (Node  : ${root_node_type_name};
          LV    : in out Logic_Var_Record;
          Field : String);
       --  Assign a name to the LV logic variable. Node must be the node that
@@ -2901,7 +2877,7 @@ package body ${ada_lib_name}.Implementation is
       ------------
 
       procedure Assign
-        (Node  : access ${root_node_value_type};
+        (Node  : ${root_node_type_name};
          LV    : in out Logic_Var_Record;
          Field : String) is
       begin
@@ -3021,8 +2997,7 @@ package body ${ada_lib_name}.Implementation is
    -- Length --
    ------------
 
-   function Length
-     (Node : access ${generic_list_value_type}) return Natural
+   function Length (Node : ${generic_list_type_name}) return Natural
    is (Children_Count
          (${T.root_node.internal_conversion(ctx.generic_list_type, 'Node')}));
 
@@ -3190,7 +3165,7 @@ package body ${ada_lib_name}.Implementation is
       -----------------
 
       function Trace_Image
-        (Node       : access ${root_node_value_type};
+        (Node       : ${root_node_type_name};
          Decoration : Boolean := True) return String is
       begin
          if Node = null then
@@ -3218,8 +3193,7 @@ package body ${ada_lib_name}.Implementation is
    -- Kind_Name --
    ---------------
 
-   function Kind_Name
-     (Node : access ${root_node_value_type}) return String is
+   function Kind_Name (Node : ${root_node_type_name}) return String is
    begin
       return To_String (Kind_Names (Node.Kind));
    end Kind_Name;
@@ -3228,9 +3202,7 @@ package body ${ada_lib_name}.Implementation is
    -- Children_Count --
    --------------------
 
-   function Children_Count
-     (Node : access ${root_node_value_type}) return Natural
-   is
+   function Children_Count (Node : ${root_node_type_name}) return Natural is
       C : Integer := Kind_To_Node_Children_Count (Node.Kind);
    begin
       if C = -1 then
@@ -3245,7 +3217,7 @@ package body ${ada_lib_name}.Implementation is
    -- Reset_Logic_Vars --
    ----------------------
 
-   procedure Reset_Logic_Vars (Node : access ${root_node_value_type}) is
+   procedure Reset_Logic_Vars (Node : ${root_node_type_name}) is
 
       procedure Reset (LV : in out Logic_Var_Record);
       --  Reset the LV logic variable, clearing the value it stores
@@ -3451,17 +3423,14 @@ package body ${ada_lib_name}.Implementation is
 
    procedure Reset_Envs (Unit : Internal_Unit) is
 
-      procedure Deactivate_Refd_Envs
-        (Node : access ${root_node_value_type});
-      procedure Recompute_Refd_Envs
-        (Node : access ${root_node_value_type});
+      procedure Deactivate_Refd_Envs (Node : ${root_node_type_name});
+      procedure Recompute_Refd_Envs (Node : ${root_node_type_name});
 
       --------------------------
       -- Deactivate_Refd_Envs --
       --------------------------
 
-      procedure Deactivate_Refd_Envs
-        (Node : access ${root_node_value_type}) is
+      procedure Deactivate_Refd_Envs (Node : ${root_node_type_name}) is
       begin
          if Node = null then
             return;
@@ -3477,8 +3446,7 @@ package body ${ada_lib_name}.Implementation is
       -- Recompute_Refd_Envs --
       -------------------------
 
-      procedure Recompute_Refd_Envs
-        (Node : access ${root_node_value_type}) is
+      procedure Recompute_Refd_Envs (Node : ${root_node_type_name}) is
       begin
          if Node = null then
             return;
@@ -3908,7 +3876,7 @@ package body ${ada_lib_name}.Implementation is
    -- Reroot_Foreign_Nodes --
    --------------------------
 
-   procedure Reroot_Foreign_Node (Node : access ${root_node_value_type}) is
+   procedure Reroot_Foreign_Node (Node : ${root_node_type_name}) is
       Unit : constant Internal_Unit := Node.Unit;
    begin
 
@@ -3946,9 +3914,7 @@ package body ${ada_lib_name}.Implementation is
    -- Text --
    ----------
 
-   function Text
-     (Node : access ${root_node_value_type}) return ${T.String.name}
-   is
+   function Text (Node : ${root_node_type_name}) return ${T.String.name} is
       T      : constant Text_Type := Text (Node);
       Result : constant ${T.String.name} :=
          ${T.String.constructor_name} (T'Length);

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -133,14 +133,14 @@ package body ${ada_lib_name}.Implementation is
 
    function Solve_Wrapper
      (R            : Relation;
-      Context_Node : ${root_node_type_name}) return Boolean;
+      Context_Node : ${T.root_node.name}) return Boolean;
    --  Wrapper for Langkit_Support.Adalog.Solve; will handle setting the debug
    --  strings in the equation if in debug mode.
 
    procedure Destroy (Env : in out Lexical_Env_Access);
 
-   function Snaps_At_Start (Self : ${root_node_type_name}) return Boolean;
-   function Snaps_At_End (Self : ${root_node_type_name}) return Boolean;
+   function Snaps_At_Start (Self : ${T.root_node.name}) return Boolean;
+   function Snaps_At_End (Self : ${T.root_node.name}) return Boolean;
 
    --  Those maps are used to give unique ids to lexical envs while pretty
    --  printing them.
@@ -678,7 +678,7 @@ package body ${ada_lib_name}.Implementation is
          Unit.Context.In_Populate_Lexical_Env;
 
       procedure Reset_Envs_Caches (Unit : Internal_Unit) is
-         procedure Internal (Node : ${root_node_type_name}) is
+         procedure Internal (Node : ${T.root_node.name}) is
          begin
             if Node = null then
                return;
@@ -806,7 +806,7 @@ package body ${ada_lib_name}.Implementation is
    -- Root --
    ----------
 
-   function Root (Unit : Internal_Unit) return ${root_node_type_name} is
+   function Root (Unit : Internal_Unit) return ${T.root_node.name} is
      (Unit.AST_Root);
 
    -----------------
@@ -864,7 +864,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    procedure Dump_Lexical_Env (Unit : Internal_Unit) is
-      Node     : constant ${root_node_type_name} := Unit.AST_Root;
+      Node     : constant ${T.root_node.name} := Unit.AST_Root;
       Root_Env : constant Lexical_Env := Unit.Context.Root_Scope;
       State    : Dump_Lexical_Env_State := (Root_Env => Root_Env, others => <>);
 
@@ -886,7 +886,7 @@ package body ${ada_lib_name}.Implementation is
       -- Internal --
       --------------
 
-      procedure Internal (Current : ${root_node_type_name}) is
+      procedure Internal (Current : ${T.root_node.name}) is
          Explore_Parent : Boolean := False;
          Env, Parent    : Lexical_Env;
       begin
@@ -919,7 +919,7 @@ package body ${ada_lib_name}.Implementation is
       --  This procedure implements the main recursive logic of dumping the
       --  environments.
    begin
-      Internal (${root_node_type_name} (Node));
+      Internal (${T.root_node.name} (Node));
    end Dump_Lexical_Env;
 
    -----------
@@ -1000,7 +1000,7 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Token_Node --
    -------------------
 
-   function Is_Token_Node (Node : ${root_node_type_name}) return Boolean is
+   function Is_Token_Node (Node : ${T.root_node.name}) return Boolean is
    begin
       return Is_Token_Node (Node.Kind);
    end Is_Token_Node;
@@ -1009,7 +1009,7 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Synthetic --
    ------------------
 
-   function Is_Synthetic (Node : ${root_node_type_name}) return Boolean is
+   function Is_Synthetic (Node : ${T.root_node.name}) return Boolean is
    begin
       return Node.Kind in Synthetic_Nodes;
    end Is_Synthetic;
@@ -1057,7 +1057,7 @@ package body ${ada_lib_name}.Implementation is
 
    % if ctx.has_env_assoc:
       procedure Add_To_Env
-        (Self        : ${root_node_type_name};
+        (Self        : ${T.root_node.name};
          Mapping     : ${T.env_assoc.name};
          Initial_Env : Lexical_Env;
          Resolver    : Entity_Resolver);
@@ -1067,7 +1067,7 @@ package body ${ada_lib_name}.Implementation is
 
    % if ctx.has_ref_env:
       procedure Ref_Env
-        (Self                : ${root_node_type_name};
+        (Self                : ${T.root_node.name};
          Dest_Env            : Lexical_Env;
          Ref_Env_Nodes       : in out ${T.root_node.array.name};
          Resolver            : Lexical_Env_Resolver;
@@ -1084,7 +1084,7 @@ package body ${ada_lib_name}.Implementation is
 
    function Solve_Wrapper
      (R            : Relation;
-      Context_Node : ${root_node_type_name}) return Boolean is
+      Context_Node : ${T.root_node.name}) return Boolean is
    begin
       if Context_Node /= null and then Langkit_Support.Adalog.Debug.Debug then
          Assign_Names_To_Logic_Vars (Context_Node);
@@ -1106,7 +1106,7 @@ package body ${ada_lib_name}.Implementation is
       ----------------
 
       procedure Add_To_Env
-        (Self        : ${root_node_type_name};
+        (Self        : ${T.root_node.name};
          Mapping     : ${T.env_assoc.name};
          Initial_Env : Lexical_Env;
          Resolver    : Entity_Resolver)
@@ -1181,7 +1181,7 @@ package body ${ada_lib_name}.Implementation is
       -------------
 
       procedure Ref_Env
-        (Self                : ${root_node_type_name};
+        (Self                : ${T.root_node.name};
          Dest_Env            : Lexical_Env;
          Ref_Env_Nodes       : in out ${T.root_node.array.name};
          Resolver            : Lexical_Env_Resolver;
@@ -1220,12 +1220,12 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    procedure Initialize
-     (Self              : ${root_node_type_name};
+     (Self              : ${T.root_node.name};
       Kind              : ${root_node_kind_name};
       Unit              : Internal_Unit;
       Token_Start_Index : Token_Index;
       Token_End_Index   : Token_Index;
-      Parent            : ${root_node_type_name} := null;
+      Parent            : ${T.root_node.name} := null;
       Self_Env          : Lexical_Env := AST_Envs.Empty_Env) is
    begin
       Self.Parent := Parent;
@@ -1246,7 +1246,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------------
 
    function Pre_Env_Actions
-     (Self                : ${root_node_type_name};
+     (Self                : ${T.root_node.name};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return AST_Envs.Lexical_Env
    is
@@ -1268,7 +1268,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    procedure Post_Env_Actions
-     (Self                : ${root_node_type_name};
+     (Self                : ${T.root_node.name};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env) is
    begin
       <%self:case_dispatch pred="${lambda n: n.env_spec}">
@@ -1290,7 +1290,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    function Get_Symbol
-     (Node : ${root_node_type_name}) return Symbol_Type is
+     (Node : ${T.root_node.name}) return Symbol_Type is
    begin
       return Get_Symbol (Token (Node, Node.Token_Start_Index));
    end Get_Symbol;
@@ -1300,7 +1300,7 @@ package body ${ada_lib_name}.Implementation is
    ----------
 
    function Text
-     (Node : ${root_node_type_name}) return Text_Type
+     (Node : ${T.root_node.name}) return Text_Type
    is
       Start_T : constant Token_Reference :=
          Token (Node, Node.Token_Start_Index);
@@ -1325,9 +1325,9 @@ package body ${ada_lib_name}.Implementation is
 
    function Is_Visible_From
      (Referenced_Env, Base_Env : AST_Envs.Lexical_Env) return Boolean is
-      Referenced_Node : constant ${root_node_type_name} :=
+      Referenced_Node : constant ${T.root_node.name} :=
          Referenced_Env.Env.Node;
-      Base_Node       : constant ${root_node_type_name} := Base_Env.Env.Node;
+      Base_Node       : constant ${T.root_node.name} := Base_Env.Env.Node;
    begin
       if Referenced_Node = null then
          raise Property_Error with
@@ -1343,7 +1343,7 @@ package body ${ada_lib_name}.Implementation is
    -- Unit --
    ----------
 
-   function Unit (Node : ${root_node_type_name}) return Internal_Unit is
+   function Unit (Node : ${T.root_node.name}) return Internal_Unit is
    begin
       return Node.Unit;
    end Unit;
@@ -1352,13 +1352,13 @@ package body ${ada_lib_name}.Implementation is
    ${array_types.body(T.root_node.entity.array)}
 
    function Lookup_Internal
-     (Node : ${root_node_type_name};
-      Sloc : Source_Location) return ${root_node_type_name};
+     (Node : ${T.root_node.name};
+      Sloc : Source_Location) return ${T.root_node.name};
    procedure Lookup_Relative
-     (Node       : ${root_node_type_name};
+     (Node       : ${T.root_node.name};
       Sloc       : Source_Location;
       Position   : out Relative_Position;
-      Node_Found : out ${root_node_type_name});
+      Node_Found : out ${T.root_node.name});
    --  Implementation helpers for the looking up process
 
    -----------------
@@ -1366,14 +1366,14 @@ package body ${ada_lib_name}.Implementation is
    -----------------
 
    procedure Set_Parents
-     (Node, Parent : ${root_node_type_name})
+     (Node, Parent : ${T.root_node.name})
    is
    begin
       if Node = null then
          return;
       end if;
 
-      Node.Parent := ${root_node_type_name} (Parent);
+      Node.Parent := ${T.root_node.name} (Parent);
 
       for I in 1 .. Children_Count (Node) loop
          Set_Parents (Child (Node, I), Node);
@@ -1384,7 +1384,7 @@ package body ${ada_lib_name}.Implementation is
    -- Destroy --
    -------------
 
-   procedure Destroy (Node : ${root_node_type_name}) is
+   procedure Destroy (Node : ${T.root_node.name}) is
    begin
       if Node = null then
          return;
@@ -1400,10 +1400,10 @@ package body ${ada_lib_name}.Implementation is
    -- Child --
    -----------
 
-   function Child (Node  : ${root_node_type_name};
-                   Index : Positive) return ${root_node_type_name}
+   function Child (Node  : ${T.root_node.name};
+                   Index : Positive) return ${T.root_node.name}
    is
-      Result          : ${root_node_type_name};
+      Result          : ${T.root_node.name};
       Index_In_Bounds : Boolean;
    begin
       Get_Child (Node, Index, Index_In_Bounds, Result);
@@ -1415,8 +1415,8 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Traverse
-     (Node  : ${root_node_type_name};
-      Visit : access function (Node : ${root_node_type_name})
+     (Node  : ${T.root_node.name};
+      Visit : access function (Node : ${T.root_node.name})
               return Visit_Status)
      return Visit_Status
    is
@@ -1434,7 +1434,7 @@ package body ${ada_lib_name}.Implementation is
          if Status = Into then
             for I in 1 .. Children_Count (Node) loop
                declare
-                  Cur_Child : constant ${root_node_type_name} :=
+                  Cur_Child : constant ${T.root_node.name} :=
                      Child (Node, I);
 
                begin
@@ -1463,8 +1463,8 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    procedure Traverse
-     (Node  : ${root_node_type_name};
-      Visit : access function (Node : ${root_node_type_name})
+     (Node  : ${T.root_node.name};
+      Visit : access function (Node : ${T.root_node.name})
                                return Visit_Status)
    is
       Result_Status : Visit_Status;
@@ -1478,20 +1478,20 @@ package body ${ada_lib_name}.Implementation is
    ------------------------
 
    function Traverse_With_Data
-     (Node  : ${root_node_type_name};
-      Visit : access function (Node : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
+      Visit : access function (Node : ${T.root_node.name};
                                Data : in out Data_Type)
                                return Visit_Status;
       Data  : in out Data_Type)
       return Visit_Status
    is
-      function Helper (Node : ${root_node_type_name}) return Visit_Status;
+      function Helper (Node : ${T.root_node.name}) return Visit_Status;
 
       ------------
       -- Helper --
       ------------
 
-      function Helper (Node : ${root_node_type_name}) return Visit_Status is
+      function Helper (Node : ${T.root_node.name}) return Visit_Status is
       begin
          return Visit (Node, Data);
       end Helper;
@@ -1515,7 +1515,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------
 
    function Sloc_Range
-     (Node : ${root_node_type_name}) return Source_Location_Range
+     (Node : ${T.root_node.name}) return Source_Location_Range
    is
       type Token_Anchor is (T_Start, T_End);
       type Token_Pos is record
@@ -1568,18 +1568,18 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Lookup
-     (Node : ${root_node_type_name};
-      Sloc : Source_Location) return ${root_node_type_name}
+     (Node : ${T.root_node.name};
+      Sloc : Source_Location) return ${T.root_node.name}
    is
       Position : Relative_Position;
-      Result   : ${root_node_type_name};
+      Result   : ${T.root_node.name};
    begin
       if Sloc = No_Source_Location then
          return null;
       end if;
 
       Lookup_Relative
-        (${root_node_type_name} (Node), Sloc, Position, Result);
+        (${T.root_node.name} (Node), Sloc, Position, Result);
       return Result;
    end Lookup;
 
@@ -1588,8 +1588,8 @@ package body ${ada_lib_name}.Implementation is
    ---------------------
 
    function Lookup_Internal
-     (Node : ${root_node_type_name};
-      Sloc : Source_Location) return ${root_node_type_name}
+     (Node : ${T.root_node.name};
+      Sloc : Source_Location) return ${T.root_node.name}
    is
       --  For this implementation helper (i.e. internal primitive), we can
       --  assume that all lookups fall into this node's sloc range.
@@ -1598,7 +1598,7 @@ package body ${ada_lib_name}.Implementation is
       Children : constant ${root_node_array.array_type_name} :=
          Implementation.Children (Node);
       Pos      : Relative_Position;
-      Result   : ${root_node_type_name};
+      Result   : ${T.root_node.name};
    begin
       --  Look for a child node that contains Sloc (i.e. return the most
       --  precise result).
@@ -1639,7 +1639,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Compare
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Sloc : Source_Location) return Relative_Position is
    begin
       return Compare (Sloc_Range (Node), Sloc);
@@ -1650,10 +1650,10 @@ package body ${ada_lib_name}.Implementation is
    ---------------------
 
    procedure Lookup_Relative
-     (Node       : ${root_node_type_name};
+     (Node       : ${T.root_node.name};
       Sloc       : Source_Location;
       Position   : out Relative_Position;
-      Node_Found : out ${root_node_type_name})
+      Node_Found : out ${T.root_node.name})
    is
       Result : constant Relative_Position :=
         Compare (Node, Sloc);
@@ -1669,7 +1669,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Compare
-     (Left, Right : ${root_node_type_name};
+     (Left, Right : ${T.root_node.name};
       Relation    : Comparison_Relation) return Boolean
    is
       LS, RS : Source_Location;
@@ -1692,7 +1692,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Children
-     (Node : ${root_node_type_name}) return ${root_node_array.array_type_name}
+     (Node : ${T.root_node.name}) return ${root_node_array.array_type_name}
    is
       First : constant Integer := ${root_node_array.index_type()}'First;
       Last  : constant Integer := First + Children_Count (Node) - 1;
@@ -1706,7 +1706,7 @@ package body ${ada_lib_name}.Implementation is
    end Children;
 
    function Children
-     (Node : ${root_node_type_name}) return ${root_node_array.name}
+     (Node : ${T.root_node.name}) return ${root_node_array.name}
    is
       C : ${root_node_array.array_type_name} := Children (Node);
    begin
@@ -1722,7 +1722,7 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    procedure PP_Trivia
-     (Node        : ${root_node_type_name};
+     (Node        : ${T.root_node.name};
       Line_Prefix : String := "")
    is
       Children_Prefix : constant String := Line_Prefix & "|  ";
@@ -1742,14 +1742,14 @@ package body ${ada_lib_name}.Implementation is
    -- Populate_Lexical_Env --
    --------------------------
 
-   function Populate_Lexical_Env (Node : ${root_node_type_name}) return Boolean
+   function Populate_Lexical_Env (Node : ${T.root_node.name}) return Boolean
    is
 
       Context  : constant Internal_Context := Node.Unit.Context;
       Root_Env : constant Lexical_Env := Context.Root_Scope;
 
       function Populate_Internal
-        (Node      : ${root_node_type_name};
+        (Node      : ${T.root_node.name};
          Bound_Env : Lexical_Env) return Boolean;
       --  Do the lexical env population on Node and recurse on its children
 
@@ -1758,7 +1758,7 @@ package body ${ada_lib_name}.Implementation is
       -----------------------
 
       function Populate_Internal
-        (Node      : ${root_node_type_name};
+        (Node      : ${T.root_node.name};
          Bound_Env : Lexical_Env) return Boolean
       is
          Result      : Boolean := False;
@@ -1847,7 +1847,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------------------
 
    function AST_Envs_Node_Text_Image
-     (Node  : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
       Short : Boolean := True) return Text_Type is
    begin
       if Short then
@@ -1862,7 +1862,7 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Rebindable --
    -------------------
 
-   function Is_Rebindable (Node : ${root_node_type_name}) return Boolean is
+   function Is_Rebindable (Node : ${T.root_node.name}) return Boolean is
    begin
       <% rebindable_nodes = [n for n in ctx.astnode_types
                              if n.annotations.rebindable] %>
@@ -1878,7 +1878,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------------
 
    procedure Register_Rebinding
-     (Node : ${root_node_type_name}; Rebinding : System.Address)
+     (Node : ${T.root_node.name}; Rebinding : System.Address)
    is
       pragma Warnings (Off, "possible aliasing problem for type");
       function Convert is new Ada.Unchecked_Conversion
@@ -1893,17 +1893,17 @@ package body ${ada_lib_name}.Implementation is
    --------------------
 
    function Element_Parent
-     (Node : ${root_node_type_name}) return ${root_node_type_name}
+     (Node : ${T.root_node.name}) return ${T.root_node.name}
    is (Node.Parent);
 
    ----------
    -- Hash --
    ----------
 
-   function Hash (Node : ${root_node_type_name}) return Hash_Type
+   function Hash (Node : ${T.root_node.name}) return Hash_Type
    is
       function H is new Hash_Access
-        (${root_node_value_type}, ${root_node_type_name});
+        (${T.root_node.value_type_name()}, ${T.root_node.name});
    begin
       return H (Node);
    end Hash;
@@ -2125,7 +2125,7 @@ package body ${ada_lib_name}.Implementation is
    -- Short_Text_Image --
    ----------------------
 
-   function Short_Text_Image (Self : ${root_node_type_name}) return Text_Type
+   function Short_Text_Image (Self : ${T.root_node.name}) return Text_Type
    is
    begin
       if Self = null then
@@ -2153,7 +2153,7 @@ package body ${ada_lib_name}.Implementation is
    -- Snaps_At_Start --
    --------------------
 
-   function Snaps_At_Start (Self : ${root_node_type_name}) return Boolean is
+   function Snaps_At_Start (Self : ${T.root_node.name}) return Boolean is
    begin
       <%self:case_dispatch pred="${lambda n: n.snaps_at_start}">
       <%def name="action(node)">
@@ -2169,7 +2169,7 @@ package body ${ada_lib_name}.Implementation is
    -- Snaps_At_End --
    ------------------
 
-   function Snaps_At_End (Self : ${root_node_type_name}) return Boolean is
+   function Snaps_At_End (Self : ${T.root_node.name}) return Boolean is
    begin
       <%self:case_dispatch pred="${lambda n: n.snaps_at_end}">
       <%def name="action(node)">
@@ -2186,14 +2186,14 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Parents
-     (Node         : ${root_node_type_name};
+     (Node         : ${T.root_node.name};
       Include_Self : Boolean := True)
       return ${root_node_array.name}
    is
       Count : Natural := 0;
-      Start : ${root_node_type_name} :=
-        ${root_node_type_name} (if Include_Self then Node else Node.Parent);
-      Cur   : ${root_node_type_name} := Start;
+      Start : ${T.root_node.name} :=
+        (if Include_Self then Node else Node.Parent);
+      Cur   : ${T.root_node.name} := Start;
    begin
       while Cur /= null loop
          Count := Count + 1;
@@ -2217,14 +2217,14 @@ package body ${ada_lib_name}.Implementation is
    -- First_Child_Index --
    -----------------------
 
-   function First_Child_Index (Node : ${root_node_type_name}) return Natural
+   function First_Child_Index (Node : ${T.root_node.name}) return Natural
    is (1);
 
    ----------------------
    -- Last_Child_Index --
    ----------------------
 
-   function Last_Child_Index (Node : ${root_node_type_name}) return Natural
+   function Last_Child_Index (Node : ${T.root_node.name}) return Natural
    is (Children_Count (Node));
 
    ---------------
@@ -2232,10 +2232,10 @@ package body ${ada_lib_name}.Implementation is
    ---------------
 
    procedure Get_Child
-     (Node            : ${root_node_type_name};
+     (Node            : ${T.root_node.name};
       Index           : Positive;
       Index_In_Bounds : out Boolean;
-      Result          : out ${root_node_type_name})
+      Result          : out ${T.root_node.name})
    is
       K : constant ${root_node_kind_name} := Node.Kind;
 
@@ -2306,7 +2306,7 @@ package body ${ada_lib_name}.Implementation is
    -----------
 
    procedure Print
-     (Node        : ${root_node_type_name};
+     (Node        : ${T.root_node.name};
       Show_Slocs  : Boolean;
       Line_Prefix : String := "")
    is
@@ -2366,7 +2366,7 @@ package body ${ada_lib_name}.Implementation is
          begin
             for I in Field_List'Range loop
                declare
-                  Child : constant ${root_node_type_name} :=
+                  Child : constant ${T.root_node.name} :=
                      Implementation.Child (Node, I);
                begin
                   Put (Attr_Prefix & Field_Name (Field_List (I)) & ":");
@@ -2386,8 +2386,7 @@ package body ${ada_lib_name}.Implementation is
    -- Parent --
    ------------
 
-   function Parent
-     (Node : ${root_node_type_name}) return ${root_node_type_name} is
+   function Parent (Node : ${T.root_node.name}) return ${T.root_node.name} is
    begin
       return Node.Parent;
    end Parent;
@@ -2397,7 +2396,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Stored_Token
-     (Node  : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
       Token : Token_Reference) return Token_Index
    is
       Index : constant Token_Or_Trivia_Index := Get_Token_Index (Token);
@@ -2419,7 +2418,7 @@ package body ${ada_lib_name}.Implementation is
    --------------------------
 
    function Children_With_Trivia
-     (Node : ${root_node_type_name}) return Bare_Children_Array
+     (Node : ${T.root_node.name}) return Bare_Children_Array
    is
       package Children_Vectors is new Ada.Containers.Vectors
         (Positive, Bare_Child_Record);
@@ -2433,7 +2432,7 @@ package body ${ada_lib_name}.Implementation is
       --  the returned vector.
 
       function Filter_Children
-        (Parent : ${root_node_type_name})
+        (Parent : ${T.root_node.name})
          return ${root_node_array.array_type_name};
       --  Return an array for all children in Parent that are not null and that
       --  aren't ghost nodes.
@@ -2458,7 +2457,7 @@ package body ${ada_lib_name}.Implementation is
       ---------------------
 
       function Filter_Children
-        (Parent : ${root_node_type_name})
+        (Parent : ${T.root_node.name})
          return ${root_node_array.array_type_name}
       is
          Children : constant ${root_node_array.array_type_name} :=
@@ -2511,16 +2510,16 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Ghost --
    --------------
 
-   function Is_Ghost (Node : ${root_node_type_name}) return Boolean
+   function Is_Ghost (Node : ${T.root_node.name}) return Boolean
    is (Node.Token_End_Index = No_Token_Index);
 
    -------------------
    -- Is_Incomplete --
    -------------------
 
-   function Is_Incomplete (Node : ${root_node_type_name}) return Boolean
+   function Is_Incomplete (Node : ${T.root_node.name}) return Boolean
    is
-      LGC : ${root_node_type_name};
+      LGC : ${T.root_node.name};
    begin
      if Is_List_Node (Node.Kind) then
         LGC := (if Last_Child_Index (Node) /= 0
@@ -2536,14 +2535,14 @@ package body ${ada_lib_name}.Implementation is
    -- Token_Start --
    -----------------
 
-   function Token_Start (Node : ${root_node_type_name}) return Token_Reference
+   function Token_Start (Node : ${T.root_node.name}) return Token_Reference
    is (Token (Node, Node.Token_Start_Index));
 
    ---------------
    -- Token_End --
    ---------------
 
-   function Token_End (Node : ${root_node_type_name}) return Token_Reference
+   function Token_End (Node : ${T.root_node.name}) return Token_Reference
    is
      (if Node.Token_End_Index = No_Token_Index
       then Token_Start (Node)
@@ -2554,7 +2553,7 @@ package body ${ada_lib_name}.Implementation is
    -----------
 
    function Token
-     (Node  : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
       Index : Token_Index) return Token_Reference
    is
      (Wrap_Token_Reference (Token_Data (Node.Unit), (Index, No_Token_Index)));
@@ -2563,16 +2562,16 @@ package body ${ada_lib_name}.Implementation is
    -- Is_Null --
    -------------
 
-   function Is_Null (Node : ${root_node_type_name}) return Boolean
+   function Is_Null (Node : ${T.root_node.name}) return Boolean
    is (Node = null);
 
    -----------------
    -- Child_Index --
    -----------------
 
-   function Child_Index (Node : ${root_node_type_name}) return Integer
+   function Child_Index (Node : ${T.root_node.name}) return Integer
    is
-      N : ${root_node_type_name} := null;
+      N : ${T.root_node.name} := null;
    begin
       if Node.Parent = null then
          raise Property_Error with
@@ -2598,7 +2597,7 @@ package body ${ada_lib_name}.Implementation is
    -------------------
 
    function Fetch_Sibling
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name};
       Offset : Integer) return ${root_entity.name}
    is
@@ -2608,7 +2607,7 @@ package body ${ada_lib_name}.Implementation is
 
       Sibling_Index : constant Integer := Node_Index + Offset;
 
-      Sibling : constant ${root_node_type_name} :=
+      Sibling : constant ${T.root_node.name} :=
         (if Sibling_Index >= 1
          then Child (Node.Parent, Sibling_Index)
          else null);
@@ -2623,7 +2622,7 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    function Previous_Sibling
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2635,7 +2634,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Next_Sibling
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2723,7 +2722,7 @@ package body ${ada_lib_name}.Implementation is
    ------------------
 
    function Children_Env
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return Lexical_Env
    is (Rebind_Env (Node.Self_Env, E_Info));
@@ -2733,7 +2732,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Node_Env
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return Lexical_Env
    is
@@ -2790,7 +2789,7 @@ package body ${ada_lib_name}.Implementation is
    ------------
 
    function Parent
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.name} is
    begin
@@ -2803,7 +2802,7 @@ package body ${ada_lib_name}.Implementation is
    -------------
 
    function Parents
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.array.name}
    is
@@ -2824,7 +2823,7 @@ package body ${ada_lib_name}.Implementation is
    --------------
 
    function Children
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name} := ${T.entity_info.nullexpr})
       return ${root_entity.array.name}
    is
@@ -2862,10 +2861,10 @@ package body ${ada_lib_name}.Implementation is
    -- Assign_Names_To_Logic_Vars --
    --------------------------------
 
-   procedure Assign_Names_To_Logic_Vars (Node : ${root_node_type_name}) is
+   procedure Assign_Names_To_Logic_Vars (Node : ${T.root_node.name}) is
 
       procedure Assign
-        (Node  : ${root_node_type_name};
+        (Node  : ${T.root_node.name};
          LV    : in out Logic_Var_Record;
          Field : String);
       --  Assign a name to the LV logic variable. Node must be the node that
@@ -2877,7 +2876,7 @@ package body ${ada_lib_name}.Implementation is
       ------------
 
       procedure Assign
-        (Node  : ${root_node_type_name};
+        (Node  : ${T.root_node.name};
          LV    : in out Logic_Var_Record;
          Field : String) is
       begin
@@ -2948,7 +2947,7 @@ package body ${ada_lib_name}.Implementation is
    -- Can_Reach --
    ---------------
 
-   function Can_Reach (El, From : ${root_node_type_name}) return Boolean is
+   function Can_Reach (El, From : ${T.root_node.name}) return Boolean is
    begin
       --  Since this function is only used to implement sequential semantics in
       --  envs, we consider that elements coming from different units are
@@ -2964,7 +2963,7 @@ package body ${ada_lib_name}.Implementation is
    end Can_Reach;
 
    function ${root_entity.constructor_name}
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Info : ${T.entity_info.name}) return ${root_entity.name} is
    begin
       return (Node => Node, Info => Info);
@@ -2990,14 +2989,14 @@ package body ${ada_lib_name}.Implementation is
               and then Left.Info.Rebindings = Right.Info.Rebindings);
    end Compare_Entity;
 
-   procedure Destroy_Synthetic_Node (Node : in out ${root_node_type_name});
+   procedure Destroy_Synthetic_Node (Node : in out ${T.root_node.name});
    --  Helper for the Register_Destroyable above
 
    ------------
    -- Length --
    ------------
 
-   function Length (Node : ${generic_list_type_name}) return Natural
+   function Length (Node : ${ctx.generic_list_type.name}) return Natural
    is (Children_Count
          (${T.root_node.internal_conversion(ctx.generic_list_type, 'Node')}));
 
@@ -3140,9 +3139,9 @@ package body ${ada_lib_name}.Implementation is
    -- Destroy_Synthetic_Node --
    ----------------------------
 
-   procedure Destroy_Synthetic_Node (Node : in out ${root_node_type_name}) is
+   procedure Destroy_Synthetic_Node (Node : in out ${T.root_node.name}) is
       procedure Free is new Ada.Unchecked_Deallocation
-        (${root_node_value_type}, ${root_node_type_name});
+        (${T.root_node.value_type_name()}, ${T.root_node.name});
    begin
       --  Don't call Node.Destroy, as Node's children may be gone already: they
       --  have their own destructor and there is no specified order for the
@@ -3165,7 +3164,7 @@ package body ${ada_lib_name}.Implementation is
       -----------------
 
       function Trace_Image
-        (Node       : ${root_node_type_name};
+        (Node       : ${T.root_node.name};
          Decoration : Boolean := True) return String is
       begin
          if Node = null then
@@ -3193,7 +3192,7 @@ package body ${ada_lib_name}.Implementation is
    -- Kind_Name --
    ---------------
 
-   function Kind_Name (Node : ${root_node_type_name}) return String is
+   function Kind_Name (Node : ${T.root_node.name}) return String is
    begin
       return To_String (Kind_Names (Node.Kind));
    end Kind_Name;
@@ -3202,7 +3201,7 @@ package body ${ada_lib_name}.Implementation is
    -- Children_Count --
    --------------------
 
-   function Children_Count (Node : ${root_node_type_name}) return Natural is
+   function Children_Count (Node : ${T.root_node.name}) return Natural is
       C : Integer := Kind_To_Node_Children_Count (Node.Kind);
    begin
       if C = -1 then
@@ -3217,7 +3216,7 @@ package body ${ada_lib_name}.Implementation is
    -- Reset_Logic_Vars --
    ----------------------
 
-   procedure Reset_Logic_Vars (Node : ${root_node_type_name}) is
+   procedure Reset_Logic_Vars (Node : ${T.root_node.name}) is
 
       procedure Reset (LV : in out Logic_Var_Record);
       --  Reset the LV logic variable, clearing the value it stores
@@ -3384,11 +3383,11 @@ package body ${ada_lib_name}.Implementation is
    --------------------------
 
    procedure Register_Destroyable
-     (Unit : Internal_Unit; Node : ${root_node_type_name})
+     (Unit : Internal_Unit; Node : ${T.root_node.name})
    is
       procedure Helper is new Register_Destroyable_Gen
-        (${root_node_value_type},
-         ${root_node_type_name},
+        (${T.root_node.value_type_name()},
+         ${T.root_node.name},
          Destroy_Synthetic_Node);
    begin
       Helper (Unit, Node);
@@ -3423,14 +3422,14 @@ package body ${ada_lib_name}.Implementation is
 
    procedure Reset_Envs (Unit : Internal_Unit) is
 
-      procedure Deactivate_Refd_Envs (Node : ${root_node_type_name});
-      procedure Recompute_Refd_Envs (Node : ${root_node_type_name});
+      procedure Deactivate_Refd_Envs (Node : ${T.root_node.name});
+      procedure Recompute_Refd_Envs (Node : ${T.root_node.name});
 
       --------------------------
       -- Deactivate_Refd_Envs --
       --------------------------
 
-      procedure Deactivate_Refd_Envs (Node : ${root_node_type_name}) is
+      procedure Deactivate_Refd_Envs (Node : ${T.root_node.name}) is
       begin
          if Node = null then
             return;
@@ -3446,7 +3445,7 @@ package body ${ada_lib_name}.Implementation is
       -- Recompute_Refd_Envs --
       -------------------------
 
-      procedure Recompute_Refd_Envs (Node : ${root_node_type_name}) is
+      procedure Recompute_Refd_Envs (Node : ${T.root_node.name}) is
       begin
          if Node = null then
             return;
@@ -3692,7 +3691,7 @@ package body ${ada_lib_name}.Implementation is
       Result.AST_Mem_Pool := Create;
       Unit.Context.Parser.Mem_Pool := Result.AST_Mem_Pool;
 
-      Result.AST_Root := ${root_node_type_name}
+      Result.AST_Root := ${T.root_node.name}
         (Parse (Unit.Context.Parser, Rule => Unit.Rule));
       Result.Diagnostics.Append (Unit.Context.Parser.Diagnostics);
       Rotate_TDH;
@@ -3751,8 +3750,8 @@ package body ${ada_lib_name}.Implementation is
       declare
          Unit_Name     : constant String := +Unit.Filename.Base_Name;
          Context       : constant Internal_Context := Unit.Context;
-         Foreign_Nodes : ${root_node_type_name}_Vectors.Vector :=
-            ${root_node_type_name}_Vectors.Empty_Vector;
+         Foreign_Nodes : ${T.root_node.name}_Vectors.Vector :=
+            ${T.root_node.name}_Vectors.Empty_Vector;
 
          Saved_In_Populate_Lexical_Env : constant Boolean :=
             Context.In_Populate_Lexical_Env;
@@ -3850,7 +3849,7 @@ package body ${ada_lib_name}.Implementation is
 
    procedure Extract_Foreign_Nodes
      (Unit          : Internal_Unit;
-      Foreign_Nodes : in out ${root_node_type_name}_Vectors.Vector) is
+      Foreign_Nodes : in out ${T.root_node.name}_Vectors.Vector) is
    begin
       for FN of Unit.Foreign_Nodes loop
          Foreign_Nodes.Append (FN.Node);
@@ -3876,7 +3875,7 @@ package body ${ada_lib_name}.Implementation is
    -- Reroot_Foreign_Nodes --
    --------------------------
 
-   procedure Reroot_Foreign_Node (Node : ${root_node_type_name}) is
+   procedure Reroot_Foreign_Node (Node : ${T.root_node.name}) is
       Unit : constant Internal_Unit := Node.Unit;
    begin
 
@@ -3914,7 +3913,7 @@ package body ${ada_lib_name}.Implementation is
    -- Text --
    ----------
 
-   function Text (Node : ${root_node_type_name}) return ${T.String.name} is
+   function Text (Node : ${T.root_node.name}) return ${T.String.name} is
       T      : constant Text_Type := Text (Node);
       Result : constant ${T.String.name} :=
          ${T.String.constructor_name} (T'Length);

--- a/langkit/templates/pkg_implementation_body_ada.mako
+++ b/langkit/templates/pkg_implementation_body_ada.mako
@@ -1259,7 +1259,8 @@ package body ${ada_lib_name}.Implementation is
       <%self:case_dispatch pred="${lambda n: n.env_spec}">
       <%def name="action(node)">
          return ${node.name}_Pre_Env_Actions
-           (${node.name} (Self), Bound_Env, Root_Env, Add_To_Env_Only);
+           (${node.internal_conversion(T.root, 'Self')},
+            Bound_Env, Root_Env, Add_To_Env_Only);
       </%def>
       <%def name="default()"> return Null_Lexical_Env; </%def>
       </%self:case_dispatch>
@@ -1271,13 +1272,15 @@ package body ${ada_lib_name}.Implementation is
    ----------------------
 
    procedure Post_Env_Actions
-     (Self                : access ${root_node_value_type}'Class;
+     (Self                : access ${root_node_value_type};
       Bound_Env, Root_Env : AST_Envs.Lexical_Env) is
    begin
       <%self:case_dispatch pred="${lambda n: n.env_spec}">
       <%def name="action(n)">
          % if n.env_spec.post_actions:
-         ${n.name}_Post_Env_Actions (${n.name} (Self), Bound_Env, Root_Env);
+         ${n.name}_Post_Env_Actions
+           (${n.internal_conversion(T.root, 'Self')},
+            Bound_Env, Root_Env);
          % else:
          null;
          % endif

--- a/langkit/templates/pkg_implementation_spec_ada.mako
+++ b/langkit/templates/pkg_implementation_spec_ada.mako
@@ -59,7 +59,7 @@ private package ${ada_lib_name}.Implementation is
    type Internal_Unit is access all Analysis_Unit_Type;
 
    type ${root_node_value_type};
-   type ${root_node_type_name} is access all ${root_node_value_type}'Class;
+   type ${root_node_type_name} is access all ${root_node_value_type};
    --  Most generic AST node type
 
    ${T.root_node.null_constant} : constant ${root_node_type_name} := null;
@@ -75,19 +75,19 @@ private package ${ada_lib_name}.Implementation is
    % endif
 
    function Is_Null
-     (Node : access ${root_node_value_type}'Class) return Boolean;
+     (Node : access ${root_node_value_type}) return Boolean;
 
    function Short_Text_Image
-     (Self : access ${root_node_value_type}'Class) return Text_Type;
+     (Self : access ${root_node_value_type}) return Text_Type;
    --  Return a short representation of the node, containing just the kind
    --  name and the sloc, or "None" if Self is null.
 
    function Is_Token_Node
-     (Node : access ${root_node_value_type}'Class) return Boolean;
+     (Node : access ${root_node_value_type}) return Boolean;
    ${ada_doc('langkit.node_is_token_node', 3)}
 
    function Is_Synthetic
-     (Node : access ${root_node_value_type}'Class) return Boolean;
+     (Node : access ${root_node_value_type}) return Boolean;
    ${ada_doc('langkit.node_is_synthetic', 3)}
 
    ---------------------------
@@ -132,7 +132,7 @@ private package ${ada_lib_name}.Implementation is
      (Node : ${root_node_type_name}) return ${root_node_type_name};
 
    function Hash
-     (Node : access ${root_node_value_type}'Class) return Hash_Type;
+     (Node : access ${root_node_value_type}) return Hash_Type;
    function Named_Hash (Node : ${root_node_type_name}) return Hash_Type is
      (Hash (Node));
 
@@ -272,8 +272,7 @@ private package ${ada_lib_name}.Implementation is
    type ${generic_list_value_type};
    --  Base type for all lists of AST node subclasses
 
-   type ${generic_list_type_name} is
-      access all ${generic_list_value_type}'Class;
+   type ${generic_list_type_name} is access all ${generic_list_value_type};
 
    ${ctx.generic_list_type.null_constant} :
       constant ${generic_list_type_name} := null;
@@ -296,18 +295,18 @@ private package ${ada_lib_name}.Implementation is
 
    % if ctx.properties_logging:
       function Trace_Image
-        (Node       : access ${root_node_value_type}'Class;
+        (Node       : access ${root_node_value_type};
          Decoration : Boolean := True) return String;
    % endif
 
    function Is_Incomplete
-     (Node : access ${root_node_value_type}'Class) return Boolean;
+     (Node : access ${root_node_value_type}) return Boolean;
    --  Return whether this node is incomplete or not.  Incomplete nodes are a
    --  result of the parsing of a node failing as a result of a NoBacktrack
    --  parser annotation.
 
    function Kind_Name
-     (Node : access ${root_node_value_type}'Class) return String;
+     (Node : access ${root_node_value_type}) return String;
    --  Return the concrete kind for Node
 
    -------------------------------
@@ -327,19 +326,19 @@ private package ${ada_lib_name}.Implementation is
    --  list instance to another.
 
    function First_Child_Index
-     (Node : access ${root_node_value_type}'Class) return Natural;
+     (Node : access ${root_node_value_type}) return Natural;
    --  Return the index of the first child Node has
 
    function Last_Child_Index
-     (Node : access ${root_node_value_type}'Class) return Natural;
+     (Node : access ${root_node_value_type}) return Natural;
    --  Return the index of the last child Node has, or 0 if there is no child
 
    function Children_Count
-     (Node : access ${root_node_value_type}'Class) return Natural;
+     (Node : access ${root_node_value_type}) return Natural;
    --  Return the number of children that Node has
 
    procedure Get_Child
-     (Node            : access ${root_node_value_type}'Class;
+     (Node            : access ${root_node_value_type};
       Index           : Positive;
       Index_In_Bounds : out Boolean;
       Result          : out ${root_node_type_name});
@@ -350,12 +349,12 @@ private package ${ada_lib_name}.Implementation is
    --  of Result is undefined.
 
    function Child
-     (Node  : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
       Index : Positive) return ${root_node_type_name};
    --  Return the Index'th child of Node, or null if Node has no such child
 
    function Children
-     (Node : access ${root_node_value_type}'Class)
+     (Node : access ${root_node_value_type})
       return ${root_node_array.array_type_name};
    --  Return an array containing all the children of Node.
    --  This is an alternative to the Child/Children_Count pair, useful if you
@@ -363,26 +362,26 @@ private package ${ada_lib_name}.Implementation is
    --  performance hit of creating an array.
 
    function Parents
-     (Node         : access ${root_node_value_type}'Class;
+     (Node         : access ${root_node_value_type};
       Include_Self : Boolean := True)
       return ${root_node_array.name};
    --  Return the list of parents for this node. This node included in the list
    --  iff Include_Self.
 
    function Parent
-     (Node : access ${root_node_value_type}'Class)
+     (Node : access ${root_node_value_type})
       return ${root_node_type_name};
 
    function Fetch_Sibling
-     (Node   : access ${root_node_value_type}'Class;
+     (Node   : access ${root_node_value_type};
       E_Info : ${T.entity_info.name};
       Offset : Integer) return ${root_entity.name};
    --  Assuming Node is the Nth child of its parent, return the (N + Offset)'th
    --  child of the same parent, or No_Entity if there is no such sibling.
 
    function Traverse
-     (Node  : access ${root_node_value_type}'Class;
-      Visit : access function (Node : access ${root_node_value_type}'Class)
+     (Node  : access ${root_node_value_type};
+      Visit : access function (Node : access ${root_node_value_type})
                                return Visit_Status)
       return Visit_Status;
    --  Given the parent node for a subtree, traverse all syntactic nodes of
@@ -402,8 +401,8 @@ private package ${ada_lib_name}.Implementation is
    --            original call to Traverse returns Stop.
 
    procedure Traverse
-     (Node  : access ${root_node_value_type}'Class;
-      Visit : access function (Node : access ${root_node_value_type}'Class)
+     (Node  : access ${root_node_value_type};
+      Visit : access function (Node : access ${root_node_value_type})
                                return Visit_Status);
    --  This is the same as Traverse function except that no result is returned
    --  i.e. the Traverse function is called and the result is simply discarded.
@@ -412,8 +411,8 @@ private package ${ada_lib_name}.Implementation is
       type Data_Type is private;
       Reset_After_Traversal : Boolean := False;
    function Traverse_With_Data
-     (Node  : access ${root_node_value_type}'Class;
-      Visit : access function (Node : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
+      Visit : access function (Node : access ${root_node_value_type};
                                Data : in out Data_Type)
                                return Visit_Status;
       Data  : in out Data_Type)
@@ -430,23 +429,23 @@ private package ${ada_lib_name}.Implementation is
    ----------------------------------------
 
    function Sloc_Range
-     (Node : access ${root_node_value_type}'Class) return Source_Location_Range;
+     (Node : access ${root_node_value_type}) return Source_Location_Range;
    --  Return the source location range corresponding to the set of tokens from
    --  which Node was parsed.
 
    function Compare
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Sloc : Source_Location) return Relative_Position;
    --  Compare Sloc to the sloc range of Node
 
    function Lookup
-     (Node : access ${root_node_value_type}'Class;
+     (Node : access ${root_node_value_type};
       Sloc : Source_Location) return ${root_node_type_name};
    --  Look for the bottom-most AST node whose sloc range contains Sloc. Return
    --  it, or null if no such node was found.
 
    function Compare
-     (Left, Right : access ${root_node_value_type}'Class;
+     (Left, Right : access ${root_node_value_type};
       Relation    : Comparison_Relation) return Boolean;
    --  If Left and Right don't belong to the same analysis units or if one of
    --  them is null, raise a Property_Error. Otherwise, return the comparison
@@ -457,21 +456,21 @@ private package ${ada_lib_name}.Implementation is
    -------------------
 
    procedure Print
-     (Node        : access ${root_node_value_type}'Class;
+     (Node        : access ${root_node_value_type};
       Show_Slocs  : Boolean;
       Line_Prefix : String := "");
    --  Debug helper: print to standard output Node and all its children.
    --  Line_Prefix is prepended to each output line.
 
    procedure PP_Trivia
-     (Node        : access ${root_node_value_type}'Class;
+     (Node        : access ${root_node_value_type};
       Line_Prefix : String := "");
    --  Debug helper: print to standard output Node and all its children along
    --  with the trivia associated to them. Line_Prefix is prepended to each
    --  output line.
 
    procedure Assign_Names_To_Logic_Vars
-     (Node : access ${root_node_value_type}'Class);
+     (Node : access ${root_node_value_type});
    --  Debug helper: Assign names to every logical variable in the root node,
    --  so that we can trace logical variables.
 
@@ -559,7 +558,7 @@ private package ${ada_lib_name}.Implementation is
    -- Root AST node (internals) --
    -------------------------------
 
-   type ${root_node_value_type} is tagged record
+   type ${root_node_value_type} is record
       Parent : ${root_node_type_name};
       --  Reference to the parent node, or null if this is the root one
 
@@ -585,10 +584,11 @@ private package ${ada_lib_name}.Implementation is
       Last_Attempted_Child : Integer;
       --  0-based index for the last child we tried to parse for this node. -1
       --  if parsing for all children was successful.
-   end record;
+   end record
+      with Convention => C;
 
    procedure Initialize
-     (Self              : access ${root_node_value_type}'Class;
+     (Self              : access ${root_node_value_type};
       Kind              : ${root_node_kind_name};
       Unit              : Internal_Unit;
       Token_Start_Index : Token_Index;
@@ -598,7 +598,7 @@ private package ${ada_lib_name}.Implementation is
    --  Helper for parsers, to initialize a freshly allocated node
 
    function Pre_Env_Actions
-     (Self                : access ${root_node_value_type}'Class;
+     (Self                : access ${root_node_value_type};
       Bound_Env, Root_Env : Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return Lexical_Env;
    --  Internal procedure that will execute all necessary lexical env actions
@@ -609,13 +609,13 @@ private package ${ada_lib_name}.Implementation is
    --  Post_Env_Actions.
 
    procedure Post_Env_Actions
-     (Self                : access ${root_node_value_type}'Class;
+     (Self                : access ${root_node_value_type};
       Bound_Env, Root_Env : Lexical_Env);
    --  Internal procedure that will execute all post add to env actions for
    --  Node. This is meant to be called by Populate_Lexical_Env.
 
    function Get_Symbol
-     (Node : access ${root_node_value_type}'Class) return Symbol_Type
+     (Node : access ${root_node_value_type}) return Symbol_Type
       with Pre => Is_Token_Node (Node);
    --  Assuming Node is a token node, return the corresponding symbol for the
    --  token it contains.
@@ -624,7 +624,7 @@ private package ${ada_lib_name}.Implementation is
    --  Transform a Symbol into an internal String
 
    function Text
-     (Node : access ${root_node_value_type}'Class) return Text_Type;
+     (Node : access ${root_node_value_type}) return Text_Type;
    --  Retun the fragment of text from which Node was parsed
 
    ------------------------------
@@ -647,19 +647,19 @@ private package ${ada_lib_name}.Implementation is
      (Element_T  => ${root_node_type_name},
       Index_Type => Positive);
 
-   type ${generic_list_value_type} is
-      abstract new ${root_node_value_type}
-   with record
+   type ${generic_list_value_type} is record
+      Base  : ${root_node_value_type};
       Count : Natural;
       Nodes : Alloc_AST_List_Array.Element_Array_Access;
-   end record;
+   end record
+      with Convention => C;
    --  Base type for all lists of AST node subclasses
 
    function Length
-     (Node : access ${generic_list_value_type}'Class) return Natural;
+     (Node : access ${generic_list_value_type}) return Natural;
 
    function Children
-     (Node : access ${root_node_value_type}'Class)
+     (Node : access ${root_node_value_type})
       return ${root_node_array.name};
    --  Return an array containing all the children of Node.
    --  This is an alternative to the Child/Children_Count pair, useful if you
@@ -667,14 +667,14 @@ private package ${ada_lib_name}.Implementation is
    --  performance hit of creating an array.
 
    procedure Reset_Logic_Vars
-     (Node : access ${root_node_value_type}'Class);
+     (Node : access ${root_node_value_type});
    --  Reset the logic variables attached to this node
 
-   procedure Set_Parents (Node, Parent : access ${root_node_value_type}'Class);
+   procedure Set_Parents (Node, Parent : access ${root_node_value_type});
    --  Set Node.Parent to Parent, and initialize recursively the parent of all
    --  child nodes.
 
-   procedure Destroy (Node : access ${root_node_value_type}'Class);
+   procedure Destroy (Node : access ${root_node_value_type});
    --  Free the resources allocated to this node and all its children
 
    --------------------------------------
@@ -701,7 +701,7 @@ private package ${ada_lib_name}.Implementation is
    --  a Property_Error.
 
    function Populate_Lexical_Env
-     (Node : access ${root_node_value_type}'Class) return Boolean;
+     (Node : access ${root_node_value_type}) return Boolean;
    --  Populate the lexical environment for node and all its children. Return
    --  whether a Property_Error error occurred in the process.
 
@@ -710,13 +710,13 @@ private package ${ada_lib_name}.Implementation is
    -----------------------------------
 
    function Token
-     (Node  : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
       Index : Token_Index) return Token_Reference;
    --  Helper for properties. This is used to turn token indexes as stored in
    --  AST nodes into Token_Reference values.
 
    function Stored_Token
-     (Node  : access ${root_node_value_type}'Class;
+     (Node  : access ${root_node_value_type};
       Token : Token_Reference) return Token_Index;
    --  Helper for properties. This is used to turn a Token_Reference value into
    --  a Token_Index value that can be stored as a field in Node. This raises a
@@ -736,7 +736,7 @@ private package ${ada_lib_name}.Implementation is
    type Bare_Children_Array is array (Positive range <>) of Bare_Child_Record;
 
    function Children_With_Trivia
-     (Node : access ${root_node_value_type}'Class) return Bare_Children_Array;
+     (Node : access ${root_node_value_type}) return Bare_Children_Array;
    --  Implementation for Analysis.Children_With_Trivia
 
    % for astnode in no_builtins(ctx.astnode_types):
@@ -1284,7 +1284,7 @@ private package ${ada_lib_name}.Implementation is
    --  which is not in the populate lexical env queue, appending them to
    --  Foreign_Nodes. Clear Unit.Foreign_Nodes afterwards.
 
-   procedure Reroot_Foreign_Node (Node : access ${root_node_value_type}'Class);
+   procedure Reroot_Foreign_Node (Node : access ${root_node_value_type});
    --  Re-create the lexical env entry for Node. This is to be used in
    --  Flush_Populate_Lexical_Env_Queue, after reparsing removed the target
    --  lexical environment.

--- a/langkit/templates/pkg_implementation_spec_ada.mako
+++ b/langkit/templates/pkg_implementation_spec_ada.mako
@@ -74,20 +74,16 @@ private package ${ada_lib_name}.Implementation is
            ("LANGKIT.PROPERTIES", GNATCOLL.Traces.On, Stream => "&1");
    % endif
 
-   function Is_Null
-     (Node : access ${root_node_value_type}) return Boolean;
+   function Is_Null (Node : ${root_node_type_name}) return Boolean;
 
-   function Short_Text_Image
-     (Self : access ${root_node_value_type}) return Text_Type;
+   function Short_Text_Image (Self : ${root_node_type_name}) return Text_Type;
    --  Return a short representation of the node, containing just the kind
    --  name and the sloc, or "None" if Self is null.
 
-   function Is_Token_Node
-     (Node : access ${root_node_value_type}) return Boolean;
+   function Is_Token_Node (Node : ${root_node_type_name}) return Boolean;
    ${ada_doc('langkit.node_is_token_node', 3)}
 
-   function Is_Synthetic
-     (Node : access ${root_node_value_type}) return Boolean;
+   function Is_Synthetic (Node : ${root_node_type_name}) return Boolean;
    ${ada_doc('langkit.node_is_synthetic', 3)}
 
    ---------------------------
@@ -131,8 +127,7 @@ private package ${ada_lib_name}.Implementation is
    function Element_Parent
      (Node : ${root_node_type_name}) return ${root_node_type_name};
 
-   function Hash
-     (Node : access ${root_node_value_type}) return Hash_Type;
+   function Hash (Node : ${root_node_type_name}) return Hash_Type;
    function Named_Hash (Node : ${root_node_type_name}) return Hash_Type is
      (Hash (Node));
 
@@ -295,18 +290,16 @@ private package ${ada_lib_name}.Implementation is
 
    % if ctx.properties_logging:
       function Trace_Image
-        (Node       : access ${root_node_value_type};
+        (Node       : ${root_node_type_name};
          Decoration : Boolean := True) return String;
    % endif
 
-   function Is_Incomplete
-     (Node : access ${root_node_value_type}) return Boolean;
+   function Is_Incomplete (Node : ${root_node_type_name}) return Boolean;
    --  Return whether this node is incomplete or not.  Incomplete nodes are a
    --  result of the parsing of a node failing as a result of a NoBacktrack
    --  parser annotation.
 
-   function Kind_Name
-     (Node : access ${root_node_value_type}) return String;
+   function Kind_Name (Node : ${root_node_type_name}) return String;
    --  Return the concrete kind for Node
 
    -------------------------------
@@ -325,20 +318,17 @@ private package ${ada_lib_name}.Implementation is
    --  it has. For AST node lists, this is -1 as this number varies from one
    --  list instance to another.
 
-   function First_Child_Index
-     (Node : access ${root_node_value_type}) return Natural;
+   function First_Child_Index (Node : ${root_node_type_name}) return Natural;
    --  Return the index of the first child Node has
 
-   function Last_Child_Index
-     (Node : access ${root_node_value_type}) return Natural;
+   function Last_Child_Index (Node : ${root_node_type_name}) return Natural;
    --  Return the index of the last child Node has, or 0 if there is no child
 
-   function Children_Count
-     (Node : access ${root_node_value_type}) return Natural;
+   function Children_Count (Node : ${root_node_type_name}) return Natural;
    --  Return the number of children that Node has
 
    procedure Get_Child
-     (Node            : access ${root_node_value_type};
+     (Node            : ${root_node_type_name};
       Index           : Positive;
       Index_In_Bounds : out Boolean;
       Result          : out ${root_node_type_name});
@@ -349,39 +339,37 @@ private package ${ada_lib_name}.Implementation is
    --  of Result is undefined.
 
    function Child
-     (Node  : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
       Index : Positive) return ${root_node_type_name};
    --  Return the Index'th child of Node, or null if Node has no such child
 
    function Children
-     (Node : access ${root_node_value_type})
-      return ${root_node_array.array_type_name};
+     (Node : ${root_node_type_name}) return ${root_node_array.array_type_name};
    --  Return an array containing all the children of Node.
    --  This is an alternative to the Child/Children_Count pair, useful if you
    --  want the convenience of Ada arrays, and you don't care about the small
    --  performance hit of creating an array.
 
    function Parents
-     (Node         : access ${root_node_value_type};
+     (Node         : ${root_node_type_name};
       Include_Self : Boolean := True)
       return ${root_node_array.name};
    --  Return the list of parents for this node. This node included in the list
    --  iff Include_Self.
 
    function Parent
-     (Node : access ${root_node_value_type})
-      return ${root_node_type_name};
+     (Node : ${root_node_type_name}) return ${root_node_type_name};
 
    function Fetch_Sibling
-     (Node   : access ${root_node_value_type};
+     (Node   : ${root_node_type_name};
       E_Info : ${T.entity_info.name};
       Offset : Integer) return ${root_entity.name};
    --  Assuming Node is the Nth child of its parent, return the (N + Offset)'th
    --  child of the same parent, or No_Entity if there is no such sibling.
 
    function Traverse
-     (Node  : access ${root_node_value_type};
-      Visit : access function (Node : access ${root_node_value_type})
+     (Node  : ${root_node_type_name};
+      Visit : access function (Node : ${root_node_type_name})
                                return Visit_Status)
       return Visit_Status;
    --  Given the parent node for a subtree, traverse all syntactic nodes of
@@ -401,8 +389,8 @@ private package ${ada_lib_name}.Implementation is
    --            original call to Traverse returns Stop.
 
    procedure Traverse
-     (Node  : access ${root_node_value_type};
-      Visit : access function (Node : access ${root_node_value_type})
+     (Node  : ${root_node_type_name};
+      Visit : access function (Node : ${root_node_type_name})
                                return Visit_Status);
    --  This is the same as Traverse function except that no result is returned
    --  i.e. the Traverse function is called and the result is simply discarded.
@@ -411,8 +399,8 @@ private package ${ada_lib_name}.Implementation is
       type Data_Type is private;
       Reset_After_Traversal : Boolean := False;
    function Traverse_With_Data
-     (Node  : access ${root_node_value_type};
-      Visit : access function (Node : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
+      Visit : access function (Node : ${root_node_type_name};
                                Data : in out Data_Type)
                                return Visit_Status;
       Data  : in out Data_Type)
@@ -429,23 +417,23 @@ private package ${ada_lib_name}.Implementation is
    ----------------------------------------
 
    function Sloc_Range
-     (Node : access ${root_node_value_type}) return Source_Location_Range;
+     (Node : ${root_node_type_name}) return Source_Location_Range;
    --  Return the source location range corresponding to the set of tokens from
    --  which Node was parsed.
 
    function Compare
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Sloc : Source_Location) return Relative_Position;
    --  Compare Sloc to the sloc range of Node
 
    function Lookup
-     (Node : access ${root_node_value_type};
+     (Node : ${root_node_type_name};
       Sloc : Source_Location) return ${root_node_type_name};
    --  Look for the bottom-most AST node whose sloc range contains Sloc. Return
    --  it, or null if no such node was found.
 
    function Compare
-     (Left, Right : access ${root_node_value_type};
+     (Left, Right : ${root_node_type_name};
       Relation    : Comparison_Relation) return Boolean;
    --  If Left and Right don't belong to the same analysis units or if one of
    --  them is null, raise a Property_Error. Otherwise, return the comparison
@@ -456,21 +444,20 @@ private package ${ada_lib_name}.Implementation is
    -------------------
 
    procedure Print
-     (Node        : access ${root_node_value_type};
+     (Node        : ${root_node_type_name};
       Show_Slocs  : Boolean;
       Line_Prefix : String := "");
    --  Debug helper: print to standard output Node and all its children.
    --  Line_Prefix is prepended to each output line.
 
    procedure PP_Trivia
-     (Node        : access ${root_node_value_type};
+     (Node        : ${root_node_type_name};
       Line_Prefix : String := "");
    --  Debug helper: print to standard output Node and all its children along
    --  with the trivia associated to them. Line_Prefix is prepended to each
    --  output line.
 
-   procedure Assign_Names_To_Logic_Vars
-     (Node : access ${root_node_value_type});
+   procedure Assign_Names_To_Logic_Vars (Node : ${root_node_type_name});
    --  Debug helper: Assign names to every logical variable in the root node,
    --  so that we can trace logical variables.
 
@@ -588,7 +575,7 @@ private package ${ada_lib_name}.Implementation is
       with Convention => C;
 
    procedure Initialize
-     (Self              : access ${root_node_value_type};
+     (Self              : ${root_node_type_name};
       Kind              : ${root_node_kind_name};
       Unit              : Internal_Unit;
       Token_Start_Index : Token_Index;
@@ -598,7 +585,7 @@ private package ${ada_lib_name}.Implementation is
    --  Helper for parsers, to initialize a freshly allocated node
 
    function Pre_Env_Actions
-     (Self                : access ${root_node_value_type};
+     (Self                : ${root_node_type_name};
       Bound_Env, Root_Env : Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return Lexical_Env;
    --  Internal procedure that will execute all necessary lexical env actions
@@ -609,13 +596,12 @@ private package ${ada_lib_name}.Implementation is
    --  Post_Env_Actions.
 
    procedure Post_Env_Actions
-     (Self                : access ${root_node_value_type};
+     (Self                : ${root_node_type_name};
       Bound_Env, Root_Env : Lexical_Env);
    --  Internal procedure that will execute all post add to env actions for
    --  Node. This is meant to be called by Populate_Lexical_Env.
 
-   function Get_Symbol
-     (Node : access ${root_node_value_type}) return Symbol_Type
+   function Get_Symbol (Node : ${root_node_type_name}) return Symbol_Type
       with Pre => Is_Token_Node (Node);
    --  Assuming Node is a token node, return the corresponding symbol for the
    --  token it contains.
@@ -623,8 +609,7 @@ private package ${ada_lib_name}.Implementation is
    function Image (Self : Symbol_Type) return ${T.String.name};
    --  Transform a Symbol into an internal String
 
-   function Text
-     (Node : access ${root_node_value_type}) return Text_Type;
+   function Text (Node : ${root_node_type_name}) return Text_Type;
    --  Retun the fragment of text from which Node was parsed
 
    ------------------------------
@@ -655,26 +640,23 @@ private package ${ada_lib_name}.Implementation is
       with Convention => C;
    --  Base type for all lists of AST node subclasses
 
-   function Length
-     (Node : access ${generic_list_value_type}) return Natural;
+   function Length (Node : ${generic_list_type_name}) return Natural;
 
    function Children
-     (Node : access ${root_node_value_type})
-      return ${root_node_array.name};
+     (Node : ${root_node_type_name}) return ${root_node_array.name};
    --  Return an array containing all the children of Node.
    --  This is an alternative to the Child/Children_Count pair, useful if you
    --  want the convenience of ada arrays, and you don't care about the small
    --  performance hit of creating an array.
 
-   procedure Reset_Logic_Vars
-     (Node : access ${root_node_value_type});
+   procedure Reset_Logic_Vars (Node : ${root_node_type_name});
    --  Reset the logic variables attached to this node
 
-   procedure Set_Parents (Node, Parent : access ${root_node_value_type});
+   procedure Set_Parents (Node, Parent : ${root_node_type_name});
    --  Set Node.Parent to Parent, and initialize recursively the parent of all
    --  child nodes.
 
-   procedure Destroy (Node : access ${root_node_value_type});
+   procedure Destroy (Node : ${root_node_type_name});
    --  Free the resources allocated to this node and all its children
 
    --------------------------------------
@@ -701,7 +683,7 @@ private package ${ada_lib_name}.Implementation is
    --  a Property_Error.
 
    function Populate_Lexical_Env
-     (Node : access ${root_node_value_type}) return Boolean;
+     (Node : ${root_node_type_name}) return Boolean;
    --  Populate the lexical environment for node and all its children. Return
    --  whether a Property_Error error occurred in the process.
 
@@ -710,13 +692,13 @@ private package ${ada_lib_name}.Implementation is
    -----------------------------------
 
    function Token
-     (Node  : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
       Index : Token_Index) return Token_Reference;
    --  Helper for properties. This is used to turn token indexes as stored in
    --  AST nodes into Token_Reference values.
 
    function Stored_Token
-     (Node  : access ${root_node_value_type};
+     (Node  : ${root_node_type_name};
       Token : Token_Reference) return Token_Index;
    --  Helper for properties. This is used to turn a Token_Reference value into
    --  a Token_Index value that can be stored as a field in Node. This raises a
@@ -736,7 +718,7 @@ private package ${ada_lib_name}.Implementation is
    type Bare_Children_Array is array (Positive range <>) of Bare_Child_Record;
 
    function Children_With_Trivia
-     (Node : access ${root_node_value_type}) return Bare_Children_Array;
+     (Node : ${root_node_type_name}) return Bare_Children_Array;
    --  Implementation for Analysis.Children_With_Trivia
 
    % for astnode in no_builtins(ctx.astnode_types):
@@ -1284,7 +1266,7 @@ private package ${ada_lib_name}.Implementation is
    --  which is not in the populate lexical env queue, appending them to
    --  Foreign_Nodes. Clear Unit.Foreign_Nodes afterwards.
 
-   procedure Reroot_Foreign_Node (Node : access ${root_node_value_type});
+   procedure Reroot_Foreign_Node (Node : ${root_node_type_name});
    --  Re-create the lexical env entry for Node. This is to be used in
    --  Flush_Populate_Lexical_Env_Queue, after reparsing removed the target
    --  lexical environment.

--- a/langkit/templates/pkg_implementation_spec_ada.mako
+++ b/langkit/templates/pkg_implementation_spec_ada.mako
@@ -425,11 +425,6 @@ private package ${ada_lib_name}.Implementation is
    --  Traverse_With_Data returns no matter what Visit does. Visit can change
    --  it otherwise.
 
-   function Child_Index
-     (Node : access ${root_node_value_type}'Class)
-      return Natural;
-   --  Return the 0-based index for Node in its parent's children
-
    ----------------------------------------
    -- Source location-related operations --
    ----------------------------------------

--- a/langkit/templates/pkg_implementation_spec_ada.mako
+++ b/langkit/templates/pkg_implementation_spec_ada.mako
@@ -58,11 +58,11 @@ private package ${ada_lib_name}.Implementation is
    type Analysis_Unit_Type;
    type Internal_Unit is access all Analysis_Unit_Type;
 
-   type ${root_node_value_type};
-   type ${root_node_type_name} is access all ${root_node_value_type};
+   type ${T.root_node.value_type_name()};
+   type ${T.root_node.name} is access all ${T.root_node.value_type_name()};
    --  Most generic AST node type
 
-   ${T.root_node.null_constant} : constant ${root_node_type_name} := null;
+   ${T.root_node.null_constant} : constant ${T.root_node.name} := null;
 
    type Rewriting_Handle_Pointer is new System.Address;
    No_Rewriting_Handle_Pointer : constant Rewriting_Handle_Pointer :=
@@ -74,16 +74,16 @@ private package ${ada_lib_name}.Implementation is
            ("LANGKIT.PROPERTIES", GNATCOLL.Traces.On, Stream => "&1");
    % endif
 
-   function Is_Null (Node : ${root_node_type_name}) return Boolean;
+   function Is_Null (Node : ${T.root_node.name}) return Boolean;
 
-   function Short_Text_Image (Self : ${root_node_type_name}) return Text_Type;
+   function Short_Text_Image (Self : ${T.root_node.name}) return Text_Type;
    --  Return a short representation of the node, containing just the kind
    --  name and the sloc, or "None" if Self is null.
 
-   function Is_Token_Node (Node : ${root_node_type_name}) return Boolean;
+   function Is_Token_Node (Node : ${T.root_node.name}) return Boolean;
    ${ada_doc('langkit.node_is_token_node', 3)}
 
-   function Is_Synthetic (Node : ${root_node_type_name}) return Boolean;
+   function Is_Synthetic (Node : ${T.root_node.name}) return Boolean;
    ${ada_doc('langkit.node_is_synthetic', 3)}
 
    ---------------------------
@@ -99,23 +99,23 @@ private package ${ada_lib_name}.Implementation is
    --  The combine function on environments metadata does a boolean Or on every
    --  boolean component of the env metadata.
 
-   function Can_Reach (El, From : ${root_node_type_name}) return Boolean;
+   function Can_Reach (El, From : ${T.root_node.name}) return Boolean;
    --  Return whether El can reach From, from a sequential viewpoint. If
    --  elements are declared in different units, it will always return True,
    --  eg this does not handle general visibility issues, just sequentiality of
    --  declarations.
 
    function AST_Envs_Node_Text_Image
-     (Node  : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
       Short : Boolean := True) return Text_Type;
    --  Return a "sourcefile:lineno:columnno" corresponding to the starting sloc
    --  of Node. Used to create a human-readable representation for env.
    --  rebindings.
 
-   function Is_Rebindable (Node : ${root_node_type_name}) return Boolean;
+   function Is_Rebindable (Node : ${T.root_node.name}) return Boolean;
 
    procedure Register_Rebinding
-     (Node : ${root_node_type_name}; Rebinding : System.Address);
+     (Node : ${T.root_node.name}; Rebinding : System.Address);
    --  Register a rebinding to be destroyed when Node's analysis unit is
    --  destroyed or reparsed.
    --
@@ -125,10 +125,10 @@ private package ${ada_lib_name}.Implementation is
    --  Env_Rebindings and on the analysis unit record.
 
    function Element_Parent
-     (Node : ${root_node_type_name}) return ${root_node_type_name};
+     (Node : ${T.root_node.name}) return ${T.root_node.name};
 
-   function Hash (Node : ${root_node_type_name}) return Hash_Type;
-   function Named_Hash (Node : ${root_node_type_name}) return Hash_Type is
+   function Hash (Node : ${T.root_node.name}) return Hash_Type;
+   function Named_Hash (Node : ${T.root_node.name}) return Hash_Type is
      (Hash (Node));
 
    No_Analysis_Unit : constant Internal_Unit := null;
@@ -152,7 +152,7 @@ private package ${ada_lib_name}.Implementation is
       No_Unit                  => No_Analysis_Unit,
       Get_Unit_Version         => Unit_Version,
       Get_Context_Version      => Context_Version,
-      Node_Type                => ${root_node_type_name},
+      Node_Type                => ${T.root_node.name},
       Node_Metadata            => ${T.env_md.name},
       No_Node                  => null,
       Empty_Metadata           => No_Metadata,
@@ -175,7 +175,7 @@ private package ${ada_lib_name}.Implementation is
      (null, ${T.entity_info.nullexpr});
 
    function ${root_entity.constructor_name}
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Info : ${T.entity_info.name}) return ${root_entity.name};
 
    function Hash_Entity (Self : ${root_entity.name}) return Hash_Type;
@@ -264,13 +264,14 @@ private package ${ada_lib_name}.Implementation is
    -- AST node derived types (incomplete declarations) --
    ------------------------------------------------------
 
-   type ${generic_list_value_type};
+   type ${ctx.generic_list_type.value_type_name()};
    --  Base type for all lists of AST node subclasses
 
-   type ${generic_list_type_name} is access all ${generic_list_value_type};
+   type ${ctx.generic_list_type.name} is access all
+   ${ctx.generic_list_type.value_type_name()};
 
    ${ctx.generic_list_type.null_constant} :
-      constant ${generic_list_type_name} := null;
+      constant ${ctx.generic_list_type.name} := null;
 
    ${astnode_types.bare_node_converters(ctx.generic_list_type)}
 
@@ -290,16 +291,16 @@ private package ${ada_lib_name}.Implementation is
 
    % if ctx.properties_logging:
       function Trace_Image
-        (Node       : ${root_node_type_name};
+        (Node       : ${T.root_node.name};
          Decoration : Boolean := True) return String;
    % endif
 
-   function Is_Incomplete (Node : ${root_node_type_name}) return Boolean;
+   function Is_Incomplete (Node : ${T.root_node.name}) return Boolean;
    --  Return whether this node is incomplete or not.  Incomplete nodes are a
    --  result of the parsing of a node failing as a result of a NoBacktrack
    --  parser annotation.
 
-   function Kind_Name (Node : ${root_node_type_name}) return String;
+   function Kind_Name (Node : ${T.root_node.name}) return String;
    --  Return the concrete kind for Node
 
    -------------------------------
@@ -318,20 +319,20 @@ private package ${ada_lib_name}.Implementation is
    --  it has. For AST node lists, this is -1 as this number varies from one
    --  list instance to another.
 
-   function First_Child_Index (Node : ${root_node_type_name}) return Natural;
+   function First_Child_Index (Node : ${T.root_node.name}) return Natural;
    --  Return the index of the first child Node has
 
-   function Last_Child_Index (Node : ${root_node_type_name}) return Natural;
+   function Last_Child_Index (Node : ${T.root_node.name}) return Natural;
    --  Return the index of the last child Node has, or 0 if there is no child
 
-   function Children_Count (Node : ${root_node_type_name}) return Natural;
+   function Children_Count (Node : ${T.root_node.name}) return Natural;
    --  Return the number of children that Node has
 
    procedure Get_Child
-     (Node            : ${root_node_type_name};
+     (Node            : ${T.root_node.name};
       Index           : Positive;
       Index_In_Bounds : out Boolean;
-      Result          : out ${root_node_type_name});
+      Result          : out ${T.root_node.name});
    --  Return the Index'th child of node, storing it into Result.
    --
    --  Child indexing is 1-based. Store in Index_In_Bounds whether Node had
@@ -339,38 +340,36 @@ private package ${ada_lib_name}.Implementation is
    --  of Result is undefined.
 
    function Child
-     (Node  : ${root_node_type_name};
-      Index : Positive) return ${root_node_type_name};
+     (Node  : ${T.root_node.name};
+      Index : Positive) return ${T.root_node.name};
    --  Return the Index'th child of Node, or null if Node has no such child
 
    function Children
-     (Node : ${root_node_type_name}) return ${root_node_array.array_type_name};
+     (Node : ${T.root_node.name}) return ${root_node_array.array_type_name};
    --  Return an array containing all the children of Node.
    --  This is an alternative to the Child/Children_Count pair, useful if you
    --  want the convenience of Ada arrays, and you don't care about the small
    --  performance hit of creating an array.
 
    function Parents
-     (Node         : ${root_node_type_name};
+     (Node         : ${T.root_node.name};
       Include_Self : Boolean := True)
       return ${root_node_array.name};
    --  Return the list of parents for this node. This node included in the list
    --  iff Include_Self.
 
-   function Parent
-     (Node : ${root_node_type_name}) return ${root_node_type_name};
+   function Parent (Node : ${T.root_node.name}) return ${T.root_node.name};
 
    function Fetch_Sibling
-     (Node   : ${root_node_type_name};
+     (Node   : ${T.root_node.name};
       E_Info : ${T.entity_info.name};
       Offset : Integer) return ${root_entity.name};
    --  Assuming Node is the Nth child of its parent, return the (N + Offset)'th
    --  child of the same parent, or No_Entity if there is no such sibling.
 
    function Traverse
-     (Node  : ${root_node_type_name};
-      Visit : access function (Node : ${root_node_type_name})
-                               return Visit_Status)
+     (Node  : ${T.root_node.name};
+      Visit : access function (Node : ${T.root_node.name}) return Visit_Status)
       return Visit_Status;
    --  Given the parent node for a subtree, traverse all syntactic nodes of
    --  this tree, calling the given function on each node in prefix order (i.e.
@@ -389,8 +388,8 @@ private package ${ada_lib_name}.Implementation is
    --            original call to Traverse returns Stop.
 
    procedure Traverse
-     (Node  : ${root_node_type_name};
-      Visit : access function (Node : ${root_node_type_name})
+     (Node  : ${T.root_node.name};
+      Visit : access function (Node : ${T.root_node.name})
                                return Visit_Status);
    --  This is the same as Traverse function except that no result is returned
    --  i.e. the Traverse function is called and the result is simply discarded.
@@ -399,8 +398,8 @@ private package ${ada_lib_name}.Implementation is
       type Data_Type is private;
       Reset_After_Traversal : Boolean := False;
    function Traverse_With_Data
-     (Node  : ${root_node_type_name};
-      Visit : access function (Node : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
+      Visit : access function (Node : ${T.root_node.name};
                                Data : in out Data_Type)
                                return Visit_Status;
       Data  : in out Data_Type)
@@ -417,23 +416,23 @@ private package ${ada_lib_name}.Implementation is
    ----------------------------------------
 
    function Sloc_Range
-     (Node : ${root_node_type_name}) return Source_Location_Range;
+     (Node : ${T.root_node.name}) return Source_Location_Range;
    --  Return the source location range corresponding to the set of tokens from
    --  which Node was parsed.
 
    function Compare
-     (Node : ${root_node_type_name};
+     (Node : ${T.root_node.name};
       Sloc : Source_Location) return Relative_Position;
    --  Compare Sloc to the sloc range of Node
 
    function Lookup
-     (Node : ${root_node_type_name};
-      Sloc : Source_Location) return ${root_node_type_name};
+     (Node : ${T.root_node.name};
+      Sloc : Source_Location) return ${T.root_node.name};
    --  Look for the bottom-most AST node whose sloc range contains Sloc. Return
    --  it, or null if no such node was found.
 
    function Compare
-     (Left, Right : ${root_node_type_name};
+     (Left, Right : ${T.root_node.name};
       Relation    : Comparison_Relation) return Boolean;
    --  If Left and Right don't belong to the same analysis units or if one of
    --  them is null, raise a Property_Error. Otherwise, return the comparison
@@ -444,20 +443,20 @@ private package ${ada_lib_name}.Implementation is
    -------------------
 
    procedure Print
-     (Node        : ${root_node_type_name};
+     (Node        : ${T.root_node.name};
       Show_Slocs  : Boolean;
       Line_Prefix : String := "");
    --  Debug helper: print to standard output Node and all its children.
    --  Line_Prefix is prepended to each output line.
 
    procedure PP_Trivia
-     (Node        : ${root_node_type_name};
+     (Node        : ${T.root_node.name};
       Line_Prefix : String := "");
    --  Debug helper: print to standard output Node and all its children along
    --  with the trivia associated to them. Line_Prefix is prepended to each
    --  output line.
 
-   procedure Assign_Names_To_Logic_Vars (Node : ${root_node_type_name});
+   procedure Assign_Names_To_Logic_Vars (Node : ${T.root_node.name});
    --  Debug helper: Assign names to every logical variable in the root node,
    --  so that we can trace logical variables.
 
@@ -545,8 +544,8 @@ private package ${ada_lib_name}.Implementation is
    -- Root AST node (internals) --
    -------------------------------
 
-   type ${root_node_value_type} is record
-      Parent : ${root_node_type_name};
+   type ${T.root_node.value_type_name()} is record
+      Parent : ${T.root_node.name};
       --  Reference to the parent node, or null if this is the root one
 
       Unit : Internal_Unit;
@@ -575,17 +574,17 @@ private package ${ada_lib_name}.Implementation is
       with Convention => C;
 
    procedure Initialize
-     (Self              : ${root_node_type_name};
+     (Self              : ${T.root_node.name};
       Kind              : ${root_node_kind_name};
       Unit              : Internal_Unit;
       Token_Start_Index : Token_Index;
       Token_End_Index   : Token_Index;
-      Parent            : ${root_node_type_name} := null;
+      Parent            : ${T.root_node.name} := null;
       Self_Env          : Lexical_Env := AST_Envs.Empty_Env);
    --  Helper for parsers, to initialize a freshly allocated node
 
    function Pre_Env_Actions
-     (Self                : ${root_node_type_name};
+     (Self                : ${T.root_node.name};
       Bound_Env, Root_Env : Lexical_Env;
       Add_To_Env_Only     : Boolean := False) return Lexical_Env;
    --  Internal procedure that will execute all necessary lexical env actions
@@ -596,12 +595,12 @@ private package ${ada_lib_name}.Implementation is
    --  Post_Env_Actions.
 
    procedure Post_Env_Actions
-     (Self                : ${root_node_type_name};
+     (Self                : ${T.root_node.name};
       Bound_Env, Root_Env : Lexical_Env);
    --  Internal procedure that will execute all post add to env actions for
    --  Node. This is meant to be called by Populate_Lexical_Env.
 
-   function Get_Symbol (Node : ${root_node_type_name}) return Symbol_Type
+   function Get_Symbol (Node : ${T.root_node.name}) return Symbol_Type
       with Pre => Is_Token_Node (Node);
    --  Assuming Node is a token node, return the corresponding symbol for the
    --  token it contains.
@@ -609,7 +608,7 @@ private package ${ada_lib_name}.Implementation is
    function Image (Self : Symbol_Type) return ${T.String.name};
    --  Transform a Symbol into an internal String
 
-   function Text (Node : ${root_node_type_name}) return Text_Type;
+   function Text (Node : ${T.root_node.name}) return Text_Type;
    --  Retun the fragment of text from which Node was parsed
 
    ------------------------------
@@ -629,34 +628,34 @@ private package ${ada_lib_name}.Implementation is
    -----------------------
 
    package Alloc_AST_List_Array is new Langkit_Support.Bump_Ptr.Array_Alloc
-     (Element_T  => ${root_node_type_name},
+     (Element_T  => ${T.root_node.name},
       Index_Type => Positive);
 
-   type ${generic_list_value_type} is record
-      Base  : ${root_node_value_type};
+   type ${ctx.generic_list_type.value_type_name()} is record
+      Base  : ${T.root_node.value_type_name()};
       Count : Natural;
       Nodes : Alloc_AST_List_Array.Element_Array_Access;
    end record
       with Convention => C;
    --  Base type for all lists of AST node subclasses
 
-   function Length (Node : ${generic_list_type_name}) return Natural;
+   function Length (Node : ${ctx.generic_list_type.name}) return Natural;
 
    function Children
-     (Node : ${root_node_type_name}) return ${root_node_array.name};
+     (Node : ${T.root_node.name}) return ${root_node_array.name};
    --  Return an array containing all the children of Node.
    --  This is an alternative to the Child/Children_Count pair, useful if you
    --  want the convenience of ada arrays, and you don't care about the small
    --  performance hit of creating an array.
 
-   procedure Reset_Logic_Vars (Node : ${root_node_type_name});
+   procedure Reset_Logic_Vars (Node : ${T.root_node.name});
    --  Reset the logic variables attached to this node
 
-   procedure Set_Parents (Node, Parent : ${root_node_type_name});
+   procedure Set_Parents (Node, Parent : ${T.root_node.name});
    --  Set Node.Parent to Parent, and initialize recursively the parent of all
    --  child nodes.
 
-   procedure Destroy (Node : ${root_node_type_name});
+   procedure Destroy (Node : ${T.root_node.name});
    --  Free the resources allocated to this node and all its children
 
    --------------------------------------
@@ -682,8 +681,7 @@ private package ${ada_lib_name}.Implementation is
    --  environments does not belong to a particular analysis unit, this raises
    --  a Property_Error.
 
-   function Populate_Lexical_Env
-     (Node : ${root_node_type_name}) return Boolean;
+   function Populate_Lexical_Env (Node : ${T.root_node.name}) return Boolean;
    --  Populate the lexical environment for node and all its children. Return
    --  whether a Property_Error error occurred in the process.
 
@@ -692,13 +690,13 @@ private package ${ada_lib_name}.Implementation is
    -----------------------------------
 
    function Token
-     (Node  : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
       Index : Token_Index) return Token_Reference;
    --  Helper for properties. This is used to turn token indexes as stored in
    --  AST nodes into Token_Reference values.
 
    function Stored_Token
-     (Node  : ${root_node_type_name};
+     (Node  : ${T.root_node.name};
       Token : Token_Reference) return Token_Index;
    --  Helper for properties. This is used to turn a Token_Reference value into
    --  a Token_Index value that can be stored as a field in Node. This raises a
@@ -708,7 +706,7 @@ private package ${ada_lib_name}.Implementation is
    type Bare_Child_Record (Kind : Child_Or_Trivia := Child) is record
       case Kind is
          when Child =>
-            Node : ${root_node_type_name};
+            Node : ${T.root_node.name};
          when Trivia =>
             Trivia : Token_Reference;
       end case;
@@ -718,7 +716,7 @@ private package ${ada_lib_name}.Implementation is
    type Bare_Children_Array is array (Positive range <>) of Bare_Child_Record;
 
    function Children_With_Trivia
-     (Node : ${root_node_type_name}) return Bare_Children_Array;
+     (Node : ${T.root_node.name}) return Bare_Children_Array;
    --  Implementation for Analysis.Children_With_Trivia
 
    % for astnode in no_builtins(ctx.astnode_types):
@@ -734,7 +732,7 @@ private package ${ada_lib_name}.Implementation is
    type Exiled_Entry is record
       Env  : Lexical_Env;
       Key  : Symbol_Type;
-      Node : ${root_node_type_name};
+      Node : ${T.root_node.name};
    end record;
    --  Tuple of values passed to AST_Envs.Add. Used in the lexical
    --  environment rerooting machinery: see Remove_Exiled_Entries and
@@ -743,7 +741,7 @@ private package ${ada_lib_name}.Implementation is
    package Exiled_Entry_Vectors is new Langkit_Support.Vectors (Exiled_Entry);
 
    type Foreign_Node_Entry is record
-      Node : ${root_node_type_name};
+      Node : ${T.root_node.name};
       --  The foreign node that has been added to an analysis unit's lexical
       --  environment.
 
@@ -755,7 +753,7 @@ private package ${ada_lib_name}.Implementation is
      (Foreign_Node_Entry);
 
    procedure Register_Destroyable
-     (Unit : Internal_Unit; Node : ${root_node_type_name});
+     (Unit : Internal_Unit; Node : ${T.root_node.name});
    --  Helper for synthetized nodes. We cannot use the generic
    --  Register_Destroyable because the root AST node is an abstract types, so
    --  this is implemented using the untyped (using System.Address)
@@ -951,7 +949,7 @@ private package ${ada_lib_name}.Implementation is
       Context : Internal_Context;
       --  The owning context for this analysis unit
 
-      AST_Root : ${root_node_type_name};
+      AST_Root : ${T.root_node.name};
 
       Filename : GNATCOLL.VFS.Virtual_File;
       --  The originating name for this analysis unit. This should be set even
@@ -1024,7 +1022,7 @@ private package ${ada_lib_name}.Implementation is
       TDH          : Token_Data_Handler;
       Diagnostics  : Diagnostics_Vectors.Vector;
       AST_Mem_Pool : Bump_Ptr_Pool;
-      AST_Root     : ${root_node_type_name};
+      AST_Root     : ${T.root_node.name};
    end record;
    --  Holder for fields affected by an analysis unit reparse. This makes it
    --  possible to separate the "reparsing" and the "replace" steps.
@@ -1176,7 +1174,7 @@ private package ${ada_lib_name}.Implementation is
      (Unit : Internal_Unit; D : Diagnostic) return String;
    --  Implementation for Analysis.Format_GNU_Diagnostic
 
-   function Root (Unit : Internal_Unit) return ${root_node_type_name};
+   function Root (Unit : Internal_Unit) return ${T.root_node.name};
    --  Implementation for Analysis.Root
 
    function First_Token (Unit : Internal_Unit) return Token_Reference;
@@ -1261,12 +1259,12 @@ private package ${ada_lib_name}.Implementation is
 
    procedure Extract_Foreign_Nodes
      (Unit          : Internal_Unit;
-      Foreign_Nodes : in out ${root_node_type_name}_Vectors.Vector);
+      Foreign_Nodes : in out ${T.root_node.name}_Vectors.Vector);
    --  Collect from Unit all the foreign nodes that belong to an analysis unit
    --  which is not in the populate lexical env queue, appending them to
    --  Foreign_Nodes. Clear Unit.Foreign_Nodes afterwards.
 
-   procedure Reroot_Foreign_Node (Node : ${root_node_type_name});
+   procedure Reroot_Foreign_Node (Node : ${T.root_node.name});
    --  Re-create the lexical env entry for Node. This is to be used in
    --  Flush_Populate_Lexical_Env_Queue, after reparsing removed the target
    --  lexical environment.

--- a/langkit/templates/pkg_introspection_body_ada.mako
+++ b/langkit/templates/pkg_introspection_body_ada.mako
@@ -614,7 +614,7 @@ package body ${ada_lib_name}.Introspection is
       Ent : constant ${T.entity.name} := Unwrap_Entity (Node);
 
       pragma Warnings (Off, "value not in range of type");
-      Result : constant ${root_node_type_name} :=
+      Result : constant ${T.root_node.name} :=
          Impl.Eval_Field (Ent.Node, Field);
       pragma Warnings (On, "value not in range of type");
    begin

--- a/langkit/templates/pkg_introspection_impl_body_ada.mako
+++ b/langkit/templates/pkg_introspection_impl_body_ada.mako
@@ -250,8 +250,8 @@ package body ${ada_lib_name}.Introspection_Implementation is
    ----------------
 
    function Eval_Field
-     (Node  : ${root_node_type_name};
-      Field : Field_Reference) return ${root_node_type_name}
+     (Node  : ${T.root_node.name};
+      Field : Field_Reference) return ${T.root_node.name}
    is
       Kind : constant ${root_node_kind_name} := Node.Kind;
    begin

--- a/langkit/templates/pkg_introspection_impl_spec_ada.mako
+++ b/langkit/templates/pkg_introspection_impl_spec_ada.mako
@@ -426,8 +426,8 @@ private package ${ada_lib_name}.Introspection_Implementation is
    --  Implementation for Introspection.Field_Type
 
    function Eval_Field
-     (Node  : ${root_node_type_name};
-      Field : Field_Reference) return ${root_node_type_name};
+     (Node  : ${T.root_node.name};
+      Field : Field_Reference) return ${T.root_node.name};
    --  Implementation for Introspection.Eval_Field
 
    function Index

--- a/langkit/templates/pkg_rewriting_impl_body_ada.mako
+++ b/langkit/templates/pkg_rewriting_impl_body_ada.mako
@@ -168,7 +168,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
                    or else Parent_Handle.Context_Handle = Context);
 
    function Allocate
-     (Node          : ${root_node_type_name};
+     (Node          : ${T.root_node.name};
       Context       : Rewriting_Handle;
       Unit_Handle   : Unit_Rewriting_Handle;
       Parent_Handle : Node_Rewriting_Handle)
@@ -413,8 +413,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
    -- Handle --
    ------------
 
-   function Handle
-     (Node : ${root_node_type_name}) return Node_Rewriting_Handle is
+   function Handle (Node : ${T.root_node.name}) return Node_Rewriting_Handle is
    begin
       ${pre_check_rw_handle('Handle (Context (Node.Unit))')}
       ${pre_check_unit_no_diags('Node.Unit')}
@@ -454,7 +453,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
    ----------
 
    function Node
-     (Handle : Node_Rewriting_Handle) return ${root_node_type_name} is
+     (Handle : Node_Rewriting_Handle) return ${T.root_node.name} is
    begin
       ${pre_check_nrw_handle('Handle')}
       return Handle.Node;
@@ -513,7 +512,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
    --------------
 
    function Allocate
-     (Node          : ${root_node_type_name};
+     (Node          : ${T.root_node.name};
       Context       : Rewriting_Handle;
       Unit_Handle   : Unit_Rewriting_Handle;
       Parent_Handle : Node_Rewriting_Handle)
@@ -544,7 +543,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
       --  Otherwise, expand to the appropriate children form: token node or
       --  regular one.
       declare
-         N           : constant ${root_node_type_name} := Node.Node;
+         N           : constant ${T.root_node.name} := Node.Node;
          Unit_Handle : constant Unit_Rewriting_Handle :=
             Handle (N.Unit);
       begin
@@ -561,7 +560,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
                  (Ada.Containers.Count_Type (Count));
                for I in 1 .. Count loop
                   declare
-                     Child : constant ${root_node_type_name} :=
+                     Child : constant ${T.root_node.name} :=
                         Implementation.Child (N, I);
                   begin
                      Children.Vector.Append
@@ -1103,7 +1102,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
             Text_Count => Text'Length);
 
          function Transform
-           (Node   : ${root_node_type_name};
+           (Node   : ${T.root_node.name};
             Parent : Node_Rewriting_Handle) return Node_Rewriting_Handle;
          --  Turn a node from the Reparsed unit into a recursively expanded
          --  node rewriting handle.
@@ -1113,7 +1112,7 @@ package body ${ada_lib_name}.Rewriting_Implementation is
          ---------------
 
          function Transform
-           (Node   : ${root_node_type_name};
+           (Node   : ${T.root_node.name};
             Parent : Node_Rewriting_Handle) return Node_Rewriting_Handle
          is
             Result : Node_Rewriting_Handle;

--- a/langkit/templates/pkg_rewriting_impl_spec_ada.mako
+++ b/langkit/templates/pkg_rewriting_impl_spec_ada.mako
@@ -39,7 +39,7 @@ private package ${ada_lib_name}.Rewriting_Implementation is
       Equivalent_Keys => "=");
 
    package Node_Maps is new Ada.Containers.Hashed_Maps
-     (Key_Type        => ${root_node_type_name},
+     (Key_Type        => ${T.root_node.name},
       Element_Type    => Node_Rewriting_Handle,
       Hash            => Named_Hash,
       Equivalent_Keys => "=");
@@ -111,7 +111,7 @@ private package ${ada_lib_name}.Rewriting_Implementation is
       Context_Handle : Rewriting_Handle;
       --  Rewriting handle for the analysis context that owns Node
 
-      Node : ${root_node_type_name};
+      Node : ${T.root_node.name};
       --  Bare AST node which this rewriting handle relates to
 
       Parent : Node_Rewriting_Handle;
@@ -215,11 +215,11 @@ private package ${ada_lib_name}.Rewriting_Implementation is
    ---------------------------------------
 
    function Handle
-     (Node : ${root_node_type_name}) return Node_Rewriting_Handle;
+     (Node : ${T.root_node.name}) return Node_Rewriting_Handle;
    --  Implementation for Rewriting.Handle
 
    function Node
-     (Handle : Node_Rewriting_Handle) return ${root_node_type_name};
+     (Handle : Node_Rewriting_Handle) return ${T.root_node.name};
    --  Implementation for Rewriting.Node
 
    function Context (Handle : Node_Rewriting_Handle) return Rewriting_Handle;

--- a/langkit/templates/pkg_unparsing_body_ada.mako
+++ b/langkit/templates/pkg_unparsing_body_ada.mako
@@ -14,7 +14,7 @@ package body ${ada_lib_name}.Unparsing is
    -------------
 
    function Unparse (Node : ${root_entity.api_name}'Class) return String is
-      N : constant ${root_node_type_name} := Unwrap_Node (Node);
+      N : constant ${T.root_node.name} := Unwrap_Node (Node);
    begin
       return Unparse
         (Create_Abstract_Node (N),

--- a/langkit/templates/pkg_unparsing_impl_body_ada.mako
+++ b/langkit/templates/pkg_unparsing_impl_body_ada.mako
@@ -79,7 +79,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
 
    function Extract_Regular_Node_Template
      (Unparser       : Regular_Node_Unparser;
-      Rewritten_Node : ${root_node_type_name}) return Regular_Node_Template;
+      Rewritten_Node : ${T.root_node.name}) return Regular_Node_Template;
    --  Return the regular node template corresponding to the instatiation of
    --  Rewritten_Node according to Unparser.
    --
@@ -107,7 +107,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
    procedure Unparse_Regular_Node
      (Node                : Abstract_Node;
       Unparser            : Regular_Node_Unparser;
-      Rewritten_Node      : ${root_node_type_name};
+      Rewritten_Node      : ${T.root_node.name};
       Preserve_Formatting : Boolean;
       Result              : in out Unparsing_Buffer);
    --  Helper for Unparse_Node, focuses on regular nodes
@@ -115,7 +115,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
    procedure Unparse_List_Node
      (Node                : Abstract_Node;
       Unparser            : List_Node_Unparser;
-      Rewritten_Node      : ${root_node_type_name};
+      Rewritten_Node      : ${T.root_node.name};
       Preserve_Formatting : Boolean;
       Result              : in out Unparsing_Buffer);
    --  Helper for Unparse_Node, focuses on list nodes
@@ -192,7 +192,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
    --------------------------
 
    function Create_Abstract_Node
-     (Parsing_Node : ${root_node_type_name}) return Abstract_Node is
+     (Parsing_Node : ${T.root_node.name}) return Abstract_Node is
    begin
       return (From_Parsing, Parsing_Node);
    end Create_Abstract_Node;
@@ -297,7 +297,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
    --------------------
 
    function Rewritten_Node
-     (Node : Abstract_Node) return ${root_node_type_name} is
+     (Node : Abstract_Node) return ${T.root_node.name} is
    begin
       case Node.Kind is
          when From_Parsing =>
@@ -334,7 +334,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
 
    function Extract_Regular_Node_Template
      (Unparser       : Regular_Node_Unparser;
-      Rewritten_Node : ${root_node_type_name}) return Regular_Node_Template
+      Rewritten_Node : ${T.root_node.name}) return Regular_Node_Template
    is
       Result     : Regular_Node_Template (True, Unparser.Field_Unparsers.N);
       Next_Token : Token_Reference;
@@ -359,7 +359,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
             T     : Token_Sequence_Access renames U.Inter_Tokens (I);
             FT    : Field_Template renames Result.Fields (I);
 
-            Rewritten_Child : constant ${root_node_type_name} :=
+            Rewritten_Child : constant ${T.root_node.name} :=
                Child (Rewritten_Node, I);
             R_Child         : constant Abstract_Node :=
                Create_Abstract_Node (Rewritten_Child);
@@ -621,7 +621,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
          Unparsing_Implementation.Kind (Node);
       Unparser : Node_Unparser renames Node_Unparsers (Kind);
 
-      Rewritten_Node : constant ${root_node_type_name} :=
+      Rewritten_Node : constant ${T.root_node.name} :=
         (if Preserve_Formatting
          then Unparsing_Implementation.Rewritten_Node (Node)
          else null);
@@ -667,7 +667,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
    procedure Unparse_Regular_Node
      (Node                : Abstract_Node;
       Unparser            : Regular_Node_Unparser;
-      Rewritten_Node      : ${root_node_type_name};
+      Rewritten_Node      : ${T.root_node.name};
       Preserve_Formatting : Boolean;
       Result              : in out Unparsing_Buffer)
    is
@@ -733,7 +733,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
    procedure Unparse_List_Node
      (Node                : Abstract_Node;
       Unparser            : List_Node_Unparser;
-      Rewritten_Node      : ${root_node_type_name};
+      Rewritten_Node      : ${T.root_node.name};
       Preserve_Formatting : Boolean;
       Result              : in out Unparsing_Buffer) is
    begin
@@ -746,7 +746,7 @@ package body ${ada_lib_name}.Unparsing_Implementation is
                and then Children_Count (Rewritten_Node) >= I
             then
                declare
-                  R_Child : constant ${root_node_type_name} :=
+                  R_Child : constant ${T.root_node.name} :=
                      Child (Rewritten_Node, I);
                   Tok : constant Token_Reference :=
                      Relative_Token (Token_Start (R_Child), -1);

--- a/langkit/templates/pkg_unparsing_impl_spec_ada.mako
+++ b/langkit/templates/pkg_unparsing_impl_spec_ada.mako
@@ -27,13 +27,13 @@ private package ${ada_lib_name}.Unparsing_Implementation is
    type Abstract_Node (Kind : Abstract_Node_Kind := Abstract_Node_Kind'First)
    is record
       case Kind is
-         when From_Parsing   => Parsing_Node   : ${root_node_type_name};
+         when From_Parsing   => Parsing_Node   : ${T.root_node.name};
          when From_Rewriting => Rewriting_Node : Node_Rewriting_Handle;
       end case;
    end record;
 
    function Create_Abstract_Node
-     (Parsing_Node : ${root_node_type_name}) return Abstract_Node;
+     (Parsing_Node : ${T.root_node.name}) return Abstract_Node;
    function Create_Abstract_Node
      (Rewriting_Node : Node_Rewriting_Handle) return Abstract_Node;
    --  Wrapping shortcuts
@@ -56,7 +56,7 @@ private package ${ada_lib_name}.Unparsing_Implementation is
    --  Assuming Node is a token node, return the associated text
 
    function Rewritten_Node
-     (Node : Abstract_Node) return ${root_node_type_name};
+     (Node : Abstract_Node) return ${T.root_node.name};
    --  If Node is a parsing node, return it. If Node is a rewritten node,
    --  return the original node (i.e. of which Node is a rewritten version), or
    --  null if there is no original node.

--- a/langkit/templates/properties/def_ada.mako
+++ b/langkit/templates/properties/def_ada.mako
@@ -33,7 +33,7 @@ is
    ## property level: we do not want to do it twice.
    <% memoized = property.memoized and not property.is_dispatcher %>
 
-   Self_As_Root_Node : constant ${root_node_type_name} :=
+   Self_As_Root_Node : constant ${T.root_node.name} :=
       ${T.root_node.internal_conversion(Self.type, 'Self')};
 
    % if property._has_self_entity:

--- a/langkit/templates/properties/def_ada.mako
+++ b/langkit/templates/properties/def_ada.mako
@@ -100,10 +100,12 @@ begin
         % if property._has_self_entity:
          & Trace_Image (Ent)
          % else:
-         & Trace_Image (Self)
+         & Trace_Image (Self_As_Root_Node)
          % endif
          % for arg in property.arguments:
-            & ", " & Trace_Image (${arg.name})
+            & ", "
+            & Trace_Image
+                (${T.root_node.internal_conversion(arg.type, arg.name)})
          % endfor
          & "):");
       Properties_Traces.Increase_Indent;
@@ -181,7 +183,11 @@ begin
 
                % if has_logging:
                   Properties_Traces.Trace
-                    ("Result: " & Trace_Image (Property_Result));
+                    ("Result: "
+                     & Trace_Image
+                         (${T.root_node.internal_conversion(
+                               property.type, 'Property_Result'
+                            )}));
                   Properties_Traces.Decrease_Indent;
                % endif
                ${gdb_memoization_return()}
@@ -252,7 +258,11 @@ begin
    % endif
 
    % if has_logging:
-      Properties_Traces.Trace ("Result: " & Trace_Image (Property_Result));
+      Properties_Traces.Trace
+        ("Result: "
+         & Trace_Image (${T.root_node.internal_conversion(
+                             property.type, 'Property_Result'
+                          )}));
       Properties_Traces.Decrease_Indent;
    % endif
 

--- a/langkit/templates/properties/def_ada.mako
+++ b/langkit/templates/properties/def_ada.mako
@@ -15,7 +15,8 @@ ${"overriding" if property.overriding else ""} function ${property.name}
    return ${property.type.name}
 is (raise Property_Error
     with "Property ${property.qualname} not implemented on type "
-    & Kind_Name (${Self.type.name} (${property.self_arg_name})));
+    & Kind_Name (${T.root_node.internal_conversion(property.struct,
+                                                   property.self_arg_name)}));
 
 % elif not property.external and not property.abstract:
 ${gdb_property_start(property)}

--- a/langkit/templates/properties/domain_ada.mako
+++ b/langkit/templates/properties/domain_ada.mako
@@ -11,13 +11,13 @@ begin
       declare
          <%
             element_type = expr.domain.type.element_type
-            is_root_type = (element_type.is_root_type
-                            if element_type.is_entity_type else
-                            element_type.is_root_node)
-
-            node_expr = 'Item.Node' if element_type.is_entity_type else 'Item'
-            if not is_root_type:
-               node_expr = '{} ({})'.format(T.root_node.name, node_expr)
+            node_type = (element_type.element_type
+                         if element_type.is_entity_type else
+                         element_type)
+            node_expr = T.root_node.internal_conversion(
+               node_type,
+               'Item.Node' if element_type.is_entity_type else 'Item'
+            )
             info_expr = 'Item.Info' if element_type.is_entity_type else '<>'
          %>
          Item : constant ${element_type.name} := Get (Dom, J);

--- a/langkit/templates/properties/helpers.mako
+++ b/langkit/templates/properties/helpers.mako
@@ -1,13 +1,7 @@
 ## vim: filetype=makoada
 
 <%def name="argument_list(property, dispatching)">
-  (${property.self_arg_name} :
-   % if Self.type.is_ast_node:
-      access ${Self.type.value_type_name()}
-   % else:
-      ${Self.type.name}
-   % endif
-
+  (${property.self_arg_name} : ${Self.type.name}
    % for arg in property.arguments:
       ; ${arg.name} : ${arg.type.name}
       % if arg.default_value is not None:

--- a/langkit/templates/properties/new_astnode_ada.mako
+++ b/langkit/templates/properties/new_astnode_ada.mako
@@ -4,7 +4,7 @@
 
 ${result} := new ${expr.static_type.value_type_name()};
 declare
-   Result_As_Root_Node : constant ${root_node_type_name} :=
+   Result_As_Root_Node : constant ${T.root_node.name} :=
       ${T.root_node.internal_conversion(expr.static_type, result)};
 begin
    Initialize

--- a/langkit/templates/properties/new_astnode_ada.mako
+++ b/langkit/templates/properties/new_astnode_ada.mako
@@ -3,22 +3,27 @@
 <% result = expr.result_var.name %>
 
 ${result} := new ${expr.static_type.value_type_name()};
-Initialize
-  (Self => ${result},
-   Kind => ${expr.static_type.ada_kind_name},
-   Unit => Self.Unit,
+declare
+   Result_As_Root_Node : constant ${root_node_type_name} :=
+      ${T.root_node.internal_conversion(expr.static_type, result)};
+begin
+   Initialize
+     (Self => Result_As_Root_Node,
+      Kind => ${expr.static_type.ada_kind_name},
+      Unit => Self_As_Root_Node.Unit,
 
-   ## Keep the token start/end null, as expected for a synthetized node
-   Token_Start_Index => No_Token_Index,
-   Token_End_Index   => No_Token_Index,
+      ## Keep the token start/end null, as expected for a synthetized node
+      Token_Start_Index => No_Token_Index,
+      Token_End_Index   => No_Token_Index,
 
-   ## We consider the creator of a synthetized nodes as its parent even though
-   ## the latter is not a regular child.
-   Parent => ${root_node_type_name} (Self),
+      ## We consider the creator of a synthetized nodes as its parent even
+      ## though the latter is not a regular child.
+      Parent => Self_As_Root_Node,
 
-   ## The node's env is the same as the parent
-   Self_Env => Self.Self_Env);
-Register_Destroyable (Self.Unit, ${root_node_type_name} (${result}));
+      ## The node's env is the same as the parent
+      Self_Env => Self_As_Root_Node.Self_Env);
+   Register_Destroyable (Self_As_Root_Node.Unit, Result_As_Root_Node);
+end;
 
 <%
    parse_field_assocs = []

--- a/langkit/templates/properties/quantifier_ada.mako
+++ b/langkit/templates/properties/quantifier_ada.mako
@@ -17,54 +17,72 @@ ${result_var} := ${'False' if quantifier.kind == ANY else 'True'};
       ${quantifier.index_var.name} := 0;
    % endif
 
-   <% coll_expr = quantifier.collection.render_expr() %>
-   for ${codegen_element_var} of
+   declare
+      <%
+         coll_expr = quantifier.collection.render_expr()
+         if quantifier.collection.type.is_list_type:
+            coll_type = ctx.generic_list_type
+            coll_expr = coll_type.internal_conversion(
+               quantifier.collection.type, coll_expr
+            )
+         else:
+            coll_type = quantifier.collection.type
+
+      %>
+      Collection : constant ${coll_type.name} := ${coll_expr};
       % if quantifier.collection.type.is_list_type:
-         ${coll_expr}.Nodes (1 .. ${coll_expr}.Count)
-      % else:
-         ${coll_expr}.Items
+         Collection_As_Root : constant ${T.root_node.name} :=
+            ${T.root_node.internal_conversion(coll_type, 'Collection')};
       % endif
-   loop
-      ## Initialize all element variables
-      % for elt_var, init_expr in reversed(quantifier.element_vars):
-         % if init_expr:
-            ${init_expr.render_pre()}
-            ${assign_var(elt_var, init_expr.render_expr())}
+   begin
+      for ${codegen_element_var} of
+         % if quantifier.collection.type.is_list_type:
+            Collection.Nodes (1 .. Children_Count (Collection_As_Root))
+         % else:
+            Collection.Items
          % endif
-      % endfor
+      loop
+         ## Initialize all element variables
+         % for elt_var, init_expr in reversed(quantifier.element_vars):
+            % if init_expr:
+               ${init_expr.render_pre()}
+               ${assign_var(elt_var, init_expr.render_expr())}
+            % endif
+         % endfor
 
-      ${scopes.start_scope(quantifier.iter_scope)}
+         ${scopes.start_scope(quantifier.iter_scope)}
 
-      ## Bind user iteration variables
-      % if user_element_var.source_name:
-         ${gdb_bind_var(user_element_var)}
-      % endif
-      % if quantifier.index_var:
-         ${gdb_bind_var(quantifier.index_var)}
-      % endif
+         ## Bind user iteration variables
+         % if user_element_var.source_name:
+            ${gdb_bind_var(user_element_var)}
+         % endif
+         % if quantifier.index_var:
+            ${gdb_bind_var(quantifier.index_var)}
+         % endif
 
-      ${quantifier.expr.render_pre()}
+         ${quantifier.expr.render_pre()}
 
-      ## Depending on the kind of the quantifier, we want to abort as soon as
-      ## the predicate holds or as soon as it does not hold.
-      % if quantifier.kind == ANY:
-         if ${quantifier.expr.render_expr()} then
-            ${result_var} := True;
-            exit;
-         end if;
-      % else:
-         if not (${quantifier.expr.render_expr()}) then
-            ${result_var} := False;
-            exit;
-         end if;
-      % endif
+         ## Depending on the kind of the quantifier, we want to abort as soon
+         ## as the predicate holds or as soon as it does not hold.
+         % if quantifier.kind == ANY:
+            if ${quantifier.expr.render_expr()} then
+               ${result_var} := True;
+               exit;
+            end if;
+         % else:
+            if not (${quantifier.expr.render_expr()}) then
+               ${result_var} := False;
+               exit;
+            end if;
+         % endif
 
-      % if quantifier.index_var:
-         ${quantifier.index_var.name} := ${quantifier.index_var.name} + 1;
-      % endif
+         % if quantifier.index_var:
+            ${quantifier.index_var.name} := ${quantifier.index_var.name} + 1;
+         % endif
 
-      ${scopes.finalize_scope(quantifier.iter_scope)}
-   end loop;
+         ${scopes.finalize_scope(quantifier.iter_scope)}
+      end loop;
+   end;
 </%def>
 
 % if quantifier.collection.type.is_list_type:

--- a/langkit/templates/properties/untyped_wrapper_def_ada.mako
+++ b/langkit/templates/properties/untyped_wrapper_def_ada.mako
@@ -9,18 +9,27 @@ function ${property.name}
 is
    <%
       uses_einfo = property.uses_entity_info
-      args = [str(arg.name) for arg in property.natural_arguments]
+      args = ([Self.type.internal_conversion(T.root_node, 'E.Node')] +
+              [str(arg.name) for arg in property.natural_arguments])
    %>
 
    % if uses_einfo:
       E_Info : ${T.entity_info.name} :=
-         Shed_Rebindings (E.Info, E.Node.Node_Env);
+         Shed_Rebindings (E.Info, Node_Env (E.Node));
       <% args.append('E_Info') %>
    % endif
 
-   Result : constant ${property.untyped_wrapper_rtype.name} :=
-      ${Self.type.name} (E.Node).${property.name}
-         ${'({})'.format(', '.join(args)) if args else ''};
+   <%
+      property_call = '{} ({})'.format(property.name, ', '.join(args))
+      rtype = property.untyped_wrapper_rtype
+   %>
+   Result : constant ${rtype.name} :=
+      % if rtype.is_ast_node:
+         ${T.root_node.internal_conversion(Self.type, property_call)}
+      % else:
+         ${property_call}
+      % endif
+   ;
 begin
    return Result;
 end;

--- a/langkit/templates/struct_types_ada.mako
+++ b/langkit/templates/struct_types_ada.mako
@@ -353,10 +353,16 @@
                   & "null record"
                % else:
                   % for i, f in enumerate (cls.get_fields()):
+                     <%
+                        field_ref = 'R.{}'.format(f.name)
+                        if f.type.is_ast_node:
+                           field_ref = T.root_node.internal_conversion(
+                              f.type, field_ref)
+                     %>
                      % if i > 0:
                         & ", "
                      % endif
-                     & "${f.name} => " & Trace_Image (R.${f.name})
+                     & "${f.name} => " & Trace_Image (${field_ref})
                   % endfor
                % endif
                & ")");

--- a/testsuite/tests/ada_api/properties_introspection/extensions/nodes/number/bodies
+++ b/testsuite/tests/ada_api/properties_introspection/extensions/nodes/number/bodies
@@ -1,6 +1,6 @@
 --  vim: ft=ada
 
-function Bare_Number_Eval (Node : access Bare_Number_Type) return Integer is
+function Bare_Number_Eval (Node : Bare_Number) return Integer is
 begin
     return Integer'Value (Image (Text (Convert_From_Number (Node))));
 end Bare_Number_Eval;

--- a/testsuite/tests/ada_api/properties_introspection/extensions/nodes/number/bodies
+++ b/testsuite/tests/ada_api/properties_introspection/extensions/nodes/number/bodies
@@ -1,7 +1,6 @@
 --  vim: ft=ada
 
-function Bare_Number_Eval
-  (Node : access Bare_Number_Type'Class) return Integer is
+function Bare_Number_Eval (Node : access Bare_Number_Type) return Integer is
 begin
-    return Integer'Value (Image (Node.Text));
+    return Integer'Value (Image (Text (Convert_From_Number (Node))));
 end Bare_Number_Eval;

--- a/testsuite/tests/ada_api/properties_introspection/test.out
+++ b/testsuite/tests/ada_api/properties_introspection/test.out
@@ -96,6 +96,11 @@ Properties for FOO_ADDITION:
    arguments:
       <none>
 
+   child_index
+   return type: Int
+   arguments:
+      <none>
+
    previous_sibling
    return type: FooNode
    arguments:
@@ -223,6 +228,11 @@ Properties for FOO_NUMBER:
 
    token_end
    return type: Token
+   arguments:
+      <none>
+
+   child_index
+   return type: Int
    arguments:
       <none>
 
@@ -380,6 +390,11 @@ Properties for FOO_REF:
    arguments:
       <none>
 
+   child_index
+   return type: Int
+   arguments:
+      <none>
+
    previous_sibling
    return type: FooNode
    arguments:
@@ -515,6 +530,11 @@ Properties for FOO_VAR_DECL_LIST:
    arguments:
       <none>
 
+   child_index
+   return type: Int
+   arguments:
+      <none>
+
    previous_sibling
    return type: FooNode
    arguments:
@@ -634,6 +654,11 @@ Properties for FOO_NAME:
    arguments:
       <none>
 
+   child_index
+   return type: Int
+   arguments:
+      <none>
+
    previous_sibling
    return type: FooNode
    arguments:
@@ -750,6 +775,11 @@ Properties for FOO_VAR_DECL:
 
    token_end
    return type: Token
+   arguments:
+      <none>
+
+   child_index
+   return type: Int
    arguments:
       <none>
 

--- a/testsuite/tests/lexical_envs/ple_after_reparse/extensions/nodes/name/bodies
+++ b/testsuite/tests/lexical_envs/ple_after_reparse/extensions/nodes/name/bodies
@@ -1,8 +1,7 @@
 --  vim: ft=ada
 
 function P_Referenced_Unit_Or_Error
-  (Node     : access Bare_Name_Type;
-   Or_Error : Boolean) return Internal_Unit
+  (Node : Bare_Name; Or_Error : Boolean) return Internal_Unit
 is
    N         : constant Bare_Foo_Node := Convert_From_Name (Node);
    Ctx       : constant Internal_Context := N.Unit.Context;

--- a/testsuite/tests/lexical_envs/ple_after_reparse/extensions/nodes/name/bodies
+++ b/testsuite/tests/lexical_envs/ple_after_reparse/extensions/nodes/name/bodies
@@ -1,12 +1,12 @@
 --  vim: ft=ada
 
 function P_Referenced_Unit_Or_Error
-  (Node     : access Bare_Name_Type'Class;
-   Or_Error : Boolean)
-   return Internal_Unit
+  (Node     : access Bare_Name_Type;
+   Or_Error : Boolean) return Internal_Unit
 is
-   Ctx       : constant Internal_Context := Node.Unit.Context;
-   Unit_Name : String := Image (Node.Text);
+   N         : constant Bare_Foo_Node := Convert_From_Name (Node);
+   Ctx       : constant Internal_Context := N.Unit.Context;
+   Unit_Name : String := Image (Text (N));
 begin
    for C of Unit_Name loop
       if C = '.' then
@@ -28,7 +28,7 @@ begin
             Unit : constant Internal_Unit := Get_From_File
               (Ctx, Filename, "", False, Default_Grammar_Rule);
          begin
-            Reference_Unit (From => Node.Unit, Referenced => Unit);
+            Reference_Unit (From => N.Unit, Referenced => Unit);
             Populate_Lexical_Env (Unit);
             return Unit;
          end;

--- a/testsuite/tests/lexical_envs/ple_subunits/extensions/nodes/name/bodies
+++ b/testsuite/tests/lexical_envs/ple_subunits/extensions/nodes/name/bodies
@@ -1,22 +1,22 @@
 --  vim: ft=ada
 
 function P_Referenced_Unit_Or_Error
-  (Node     : access Bare_Name_Type'Class;
-   Or_Error : Boolean)
-   return Internal_Unit
+  (Node     : access Bare_Name_Type;
+   Or_Error : Boolean) return Internal_Unit
 is
-   Root           : constant Bare_Foo_Node := Node.Unit.AST_Root;
-   Requested_Name : Symbol_Type_Array_Access := Node.P_Symbols;
+   N              : constant Bare_Foo_Node := Convert_From_Name (Node);
+   Root           : constant Bare_Foo_Node := N.Unit.AST_Root;
+   Requested_Name : Symbol_Type_Array_Access := P_Symbols (Node);
    Has_Errors     : Boolean := False;
 begin
-   for I in 1 .. Root.Children_Count loop
+   for I in 1 .. Children_Count (Root) loop
       declare
-         S  : constant Bare_Scope := Bare_Scope (Root.Child (I));
-         SN : constant Bare_Name := S.F_Name;
-         N  : Symbol_Type_Array_Access := SN.P_Symbols;
+         S  : constant Bare_Foo_Node := Child (Root, I);
+         SN : constant Bare_Name := F_Name (Convert_To_Scope (S));
+         N  : Symbol_Type_Array_Access := P_Symbols (SN);
       begin
          if N.Items = Requested_Name.Items then
-            Has_Errors := S.Populate_Lexical_Env or else Has_Errors;
+            Has_Errors := Populate_Lexical_Env (S) or else Has_Errors;
          end if;
          Dec_Ref (N);
       end;
@@ -25,5 +25,5 @@ begin
    if Has_Errors then
       raise Property_Error;
    end if;
-   return Node.Unit;
+   return N.Unit;
 end P_Referenced_Unit_Or_Error;

--- a/testsuite/tests/lexical_envs/ple_subunits/extensions/nodes/name/bodies
+++ b/testsuite/tests/lexical_envs/ple_subunits/extensions/nodes/name/bodies
@@ -1,8 +1,7 @@
 --  vim: ft=ada
 
 function P_Referenced_Unit_Or_Error
-  (Node     : access Bare_Name_Type;
-   Or_Error : Boolean) return Internal_Unit
+  (Node : Bare_Name; Or_Error : Boolean) return Internal_Unit
 is
    N              : constant Bare_Foo_Node := Convert_From_Name (Node);
    Root           : constant Bare_Foo_Node := N.Unit.AST_Root;

--- a/testsuite/tests/lexical_envs/ple_subunits_2/extensions/nodes/name/bodies
+++ b/testsuite/tests/lexical_envs/ple_subunits_2/extensions/nodes/name/bodies
@@ -1,8 +1,7 @@
 --  vim: ft=ada
 
 function P_Referenced_Unit_Or_Error
-  (Node     : access Bare_Name_Type;
-   Or_Error : Boolean) return Internal_Unit
+  (Node : Bare_Name; Or_Error : Boolean) return Internal_Unit
 is
    N   : constant Bare_Foo_Node := Convert_From_Name (Node);
    Ctx : constant Internal_Context := N.Unit.Context;

--- a/testsuite/tests/lexical_envs/ple_subunits_2/extensions/nodes/name/bodies
+++ b/testsuite/tests/lexical_envs/ple_subunits_2/extensions/nodes/name/bodies
@@ -1,11 +1,11 @@
 --  vim: ft=ada
 
 function P_Referenced_Unit_Or_Error
-  (Node     : access Bare_Name_Type'Class;
-   Or_Error : Boolean)
-   return Internal_Unit
+  (Node     : access Bare_Name_Type;
+   Or_Error : Boolean) return Internal_Unit
 is
-   Ctx : constant Internal_Context := Node.Unit.Context;
+   N   : constant Bare_Foo_Node := Convert_From_Name (Node);
+   Ctx : constant Internal_Context := N.Unit.Context;
 
    AB   : constant Internal_Symbol_Type_Array :=
      (Lookup_Symbol (Ctx, "a"), Lookup_Symbol (Ctx, "b"));
@@ -13,7 +13,7 @@ is
      (Lookup_Symbol (Ctx, "a"), Lookup_Symbol (Ctx, "b"),
       Lookup_Symbol (Ctx, "c"), Lookup_Symbol (Ctx, "d"));
 
-   Requested_Name : Symbol_Type_Array_Access := Node.P_Symbols;
+   Requested_Name : Symbol_Type_Array_Access := P_Symbols (Node);
    Filename       : constant String := (if Requested_Name.Items in AB | ABCD
                                         then "source2.txt"
                                         else "source1.txt");
@@ -21,14 +21,14 @@ is
      (Ctx, Filename, "", False, Default_Grammar_Rule).AST_Root;
    Has_Errors : Boolean := False;
 begin
-   for I in 1 .. Root.Children_Count loop
+   for I in 1 .. Children_Count (Root) loop
       declare
-         S  : constant Bare_Scope := Bare_Scope (Root.Child (I));
-         SN : constant Bare_Name := S.F_Name;
-         N  : Symbol_Type_Array_Access := SN.P_Symbols;
+         S  : constant Bare_Foo_Node := Child (Root, I);
+         SN : constant Bare_Name := F_Name (Convert_To_Scope (S));
+         N  : Symbol_Type_Array_Access := P_Symbols (SN);
       begin
          if N.Items = Requested_Name.Items then
-            Has_Errors := S.Populate_Lexical_Env or else Has_Errors;
+            Has_Errors := Populate_Lexical_Env (S) or else Has_Errors;
          end if;
          Dec_Ref (N);
       end;

--- a/testsuite/tests/properties/analysis_unit/extensions/nodes/literal/bodies
+++ b/testsuite/tests/properties/analysis_unit/extensions/nodes/literal/bodies
@@ -1,7 +1,8 @@
 --  vim: ft=ada
 
-function Bare_Literal_Result (Node : access Bare_Literal_Type'Class) return Integer
+function Bare_Literal_Result (Node : access Bare_Literal_Type) return Integer
 is
+    N : constant Bare_Foo_Node := Convert_From_Literal (Node);
 begin
-    return Integer'Value (Image (Node.Text));
+    return Integer'Value (Image (Text (N)));
 end Bare_Literal_Result;

--- a/testsuite/tests/properties/analysis_unit/extensions/nodes/literal/bodies
+++ b/testsuite/tests/properties/analysis_unit/extensions/nodes/literal/bodies
@@ -1,7 +1,6 @@
 --  vim: ft=ada
 
-function Bare_Literal_Result (Node : access Bare_Literal_Type) return Integer
-is
+function Bare_Literal_Result (Node : Bare_Literal) return Integer is
     N : constant Bare_Foo_Node := Convert_From_Literal (Node);
 begin
     return Integer'Value (Image (Text (N)));

--- a/testsuite/tests/properties/analysis_unit/extensions/nodes/name/bodies
+++ b/testsuite/tests/properties/analysis_unit/extensions/nodes/name/bodies
@@ -1,10 +1,10 @@
 --  vim: ft=ada
 
-function P_Designated_Unit
-  (Node : access Bare_Name_Type'Class) return Internal_Unit
+function P_Designated_Unit (Node : access Bare_Name_Type) return Internal_Unit
 is
-    Filename : constant String := Image (Node.Text) & ".txt";
-    Context  : constant Internal_Context := Node.Unit.Context;
+    N        : constant Bare_Foo_Node := Convert_From_Name (Node);
+    Filename : constant String := Image (Text (N)) & ".txt";
+    Context  : constant Internal_Context := N.Unit.Context;
 begin
     return Get_From_File (Context, Filename, Default_Charset,
                           Reparse => False,

--- a/testsuite/tests/properties/analysis_unit/extensions/nodes/name/bodies
+++ b/testsuite/tests/properties/analysis_unit/extensions/nodes/name/bodies
@@ -1,7 +1,6 @@
 --  vim: ft=ada
 
-function P_Designated_Unit (Node : access Bare_Name_Type) return Internal_Unit
-is
+function P_Designated_Unit (Node : Bare_Name) return Internal_Unit is
     N        : constant Bare_Foo_Node := Convert_From_Name (Node);
     Filename : constant String := Image (Text (N)) & ".txt";
     Context  : constant Internal_Context := N.Unit.Context;

--- a/testsuite/tests/properties/big_integer/extensions/nodes/literal/bodies
+++ b/testsuite/tests/properties/big_integer/extensions/nodes/literal/bodies
@@ -1,7 +1,7 @@
 --  vim: ft=ada
 
 function Bare_Literal_Evaluate
-  (Node : access Bare_Literal_Type'Class) return Big_Integer_Type is
+  (Node : access Bare_Literal_Type) return Big_Integer_Type is
 begin
-   return Create_Big_Integer (Image (Node.Text));
+   return Create_Big_Integer (Image (Text (Convert_From_Literal (Node))));
 end Bare_Literal_Evaluate;

--- a/testsuite/tests/properties/big_integer/extensions/nodes/literal/bodies
+++ b/testsuite/tests/properties/big_integer/extensions/nodes/literal/bodies
@@ -1,7 +1,6 @@
 --  vim: ft=ada
 
-function Bare_Literal_Evaluate
-  (Node : access Bare_Literal_Type) return Big_Integer_Type is
+function Bare_Literal_Evaluate (Node : Bare_Literal) return Big_Integer_Type is
 begin
    return Create_Big_Integer (Image (Text (Convert_From_Literal (Node))));
 end Bare_Literal_Evaluate;

--- a/testsuite/tests/properties/external/extensions/nodes/literal/bodies
+++ b/testsuite/tests/properties/external/extensions/nodes/literal/bodies
@@ -1,7 +1,7 @@
 --  vim: ft=ada
 
-function Bare_Literal_Result
-  (Node : access Bare_Literal_Type'Class) return Integer is
+function Bare_Literal_Result (Node : access Bare_Literal_Type) return Integer
+is
 begin
-    return Integer'Value (Image (Node.Text));
+    return Integer'Value (Image (Text (Convert_From_Literal (Node))));
 end Bare_Literal_Result;

--- a/testsuite/tests/properties/external/extensions/nodes/literal/bodies
+++ b/testsuite/tests/properties/external/extensions/nodes/literal/bodies
@@ -1,7 +1,6 @@
 --  vim: ft=ada
 
-function Bare_Literal_Result (Node : access Bare_Literal_Type) return Integer
-is
+function Bare_Literal_Result (Node : Bare_Literal) return Integer is
 begin
     return Integer'Value (Image (Text (Convert_From_Literal (Node))));
 end Bare_Literal_Result;


### PR DESCRIPTION
The goal of these commits is to remove tags in bare nodes, replacing the traditional implementation of OOP inheritance (i.e. tagged record derivation) with encapsulation (the base class becomes the first field).

Most of the commits are the end of thepreparatory work to make this possible, mostly adding up-tree conversions to the appropriate node type when calling node primitives. After the tags are removed, the last commits update the GDB helpers accordingly and perform minor refactorings in templates.

As all subprograms working on bare nodes are no longer primitives, this change opens the way to generate them (especially properties) in separate source files, hopefully reducing compiler memory footprint, time to run to completion and improving build parallelization.