### PR TITLE
S924-008 Fix unwrapping of enum types

### DIFF
--- a/testsuite/tests/ocaml_api/general/main.ml
+++ b/testsuite/tests/ocaml_api/general/main.ml
@@ -343,4 +343,28 @@ let () =
     (FooNode.p_get_eacute root)
     (FooNode.p_identity root "é")
     (FooNode.p_double root "a") ;
+  Format.printf "@[<v>=======================@ @ @]"
+
+let () =
+  Format.printf "@[<v>=======ENUM=======@ @]" ;
+  let open Color in
+  let ctx = AnalysisContext.create () in
+  let u = AnalysisContext.get_from_buffer ctx "foo.txt" "my_ident" in
+  print_exit_if_diags u ;
+  let root = root_exn u in
+  let pp_color fmt = function
+    | Red ->
+        Format.pp_print_string fmt "Red"
+    | Green ->
+        Format.pp_print_string fmt "Green"
+    | Blue ->
+        Format.pp_print_string fmt "Blue"
+  in
+  let print c =
+    Format.printf "@[<v>@[color: %a;@ same_color: %a@]@ @]" pp_color c pp_color
+      (FooNode.p_same_color root c)
+  in
+  print Red ;
+  print Green ;
+  print Blue ;
   Format.printf "@[<v>=======================@ @]"

--- a/testsuite/tests/ocaml_api/general/test.out
+++ b/testsuite/tests/ocaml_api/general/test.out
@@ -368,4 +368,10 @@ get_eacute: "\195\169"
 identity é: "\195\169"
 double a: "aa"
 =======================
+
+=======ENUM=======
+color: Red; same_color: Red
+color: Green; same_color: Green
+color: Blue; same_color: Blue
+=======================
 Done

--- a/testsuite/tests/ocaml_api/general/test.py
+++ b/testsuite/tests/ocaml_api/general/test.py
@@ -5,7 +5,9 @@ Test that OCaml API is properly working.
 from __future__ import absolute_import, division, print_function
 
 from langkit.compile_context import LibraryEntity
-from langkit.dsl import ASTNode, Field, Symbol, T, has_abstract_list
+from langkit.dsl import (
+    ASTNode, Enum, EnumValue, Field, Symbol, T, has_abstract_list
+)
 from langkit.expressions import (
     ArrayLiteral, CharacterLiteral, Entity, Property, langkit_property
 )
@@ -13,6 +15,12 @@ from langkit.parsers import Grammar, List, Or
 
 from lexer_example import Token
 from utils import build_and_run
+
+
+class Color(Enum):
+    Red = EnumValue()
+    Green = EnumValue()
+    Blue = EnumValue()
 
 
 @has_abstract_list
@@ -37,6 +45,10 @@ class FooNode(ASTNode):
     @langkit_property(public=True)
     def double(c=T.Character):
         return ArrayLiteral([c, c], T.Character)
+
+    @langkit_property(public=True)
+    def same_color(c=Color):
+        return c
 
 
 class Sequence(FooNode.list):


### PR DESCRIPTION
An EnumType has a ctype view, thus, to unwrap it, it is unecessary to
call the unwrap function.

The wrap function was not being affected by the issue.

wrap and unwrap functions are required only if a type does not define a
ctype view. Thus, refactor the code to reflect this.