### PR TITLE
Always build with -fPIC and share object directories

### DIFF
--- a/langkit/libmanage.py
+++ b/langkit/libmanage.py
@@ -1040,18 +1040,19 @@ class ManageScript(object):
         add_path('PATH', self.dirs.build_dir('bin'))
         add_path('C_INCLUDE_PATH', self.dirs.build_dir('include'))
 
-        def lib_subdir(lib_name, lib_type):
+        def lib_subdir(lib_name):
             return self.dirs.build_dir(
-                'lib', lib_name, lib_type, build_mode
+                'lib', lib_name, build_mode
             )
 
         libs = ['langkit_support']
         if self.context:
             libs.append(self.lib_name.lower())
         for lib in libs:
-            add_path('LIBRARY_PATH', lib_subdir(lib, 'static'))
-            add_path('LD_LIBRARY_PATH', lib_subdir(lib, 'relocatable'))
-            add_path('PATH', lib_subdir(lib, 'relocatable'))
+            subdir = lib_subdir(lib)
+            add_path('LIBRARY_PATH', subdir)
+            add_path('LD_LIBRARY_PATH', subdir)
+            add_path('PATH', subdir)
 
         add_path('GPR_PROJECT_PATH', self.dirs.build_dir('lib', 'gnat'))
         add_path('PYTHONPATH', self.dirs.build_dir('python'))

--- a/langkit/templates/langkit_support_gpr.mako
+++ b/langkit/templates/langkit_support_gpr.mako
@@ -52,12 +52,10 @@ library project Langkit_Support is
       "Langkit_Support.Vectors");
 
    for Source_Dirs use (${string_repr(source_dir)});
-   for Library_Dir use
-      "../langkit_support/" & Library_Kind_Param & "/" & Build_Mode;
-   for Object_Dir use
-      "../../obj/langkit_support/" & Library_Kind_Param & "/" & Build_Mode;
+   for Library_Dir use "../langkit_support/" & Build_Mode;
+   for Object_Dir use "../../obj/langkit_support/" & Build_Mode;
 
-   Common_Ada_Cargs := ("-gnatwa", "-gnatyg");
+   Common_Ada_Cargs := ("-gnatwa", "-gnatyg", "-fPIC");
 
    package Compiler is
       case Build_Mode is

--- a/langkit/templates/project_file.mako
+++ b/langkit/templates/project_file.mako
@@ -38,14 +38,14 @@ library project ${lib_name} is
    for Source_Dirs use
      (${', '.join(string_repr(d) for d in source_dirs if d)});
 
-   for Library_Dir use
-      "../${lib_name.lower()}/" & Library_Kind_Param & "/" & Build_Mode;
-   for Object_Dir use
-      "../../obj/${lib_name.lower()}/" & Library_Kind_Param & "/" & Build_Mode;
+   for Library_Dir use "../${lib_name.lower()}/" & Build_Mode;
+   for Object_Dir use "../../obj/${lib_name.lower()}/" & Build_Mode;
 
    Target := ${lib_name}'Target;
 
    package Compiler is
+
+      For_All_Cargs := ("-fPIC");
 
       ----------------------
       -- Common_Ada_Cargs --
@@ -135,8 +135,8 @@ library project ${lib_name} is
             null;
       end case;
 
-      Common_Ada_Cargs := Mode_Args & Ada_Mode_Args;
-      Common_C_Cargs := Mode_Args & C_Mode_Args;
+      Common_Ada_Cargs := For_All_Cargs & Mode_Args & Ada_Mode_Args;
+      Common_C_Cargs := For_All_Cargs & Mode_Args & C_Mode_Args;
 
       for Default_Switches ("Ada") use Common_Ada_Cargs & Generated_Ada_Cargs;
       for Default_Switches ("C") use Common_C_Cargs;


### PR DESCRIPTION
This patch changes all generated project files so that builds for all
library kinds share the same object directories, and thus every unit is
compiled only once (not once for static builds, then once for
relocatable builds, etc.). Always building with -fPIC allows us to do
this as -fPIC is a requirement for relocatable and static-pic builds.

Most generated library users use -fPIC-based builds, so the (limited?)
extra bloat in generated code for static libraries seems to be worth the
reduction of build times.