### PR TITLE
SC09-060: Fix constraint_error during memoization of properties.

### DIFF
--- a/testsuite/tests/properties/invalidation_during_mmz/extensions/nodes/example/bodies
+++ b/testsuite/tests/properties/invalidation_during_mmz/extensions/nodes/example/bodies
@@ -1,0 +1,10 @@
+--  vim: ft=ada
+
+function Example_P_Fetch_Example_Unit (Node : Bare_Example) return Internal_Unit is
+    Filename : constant String := "example.txt";
+    Context  : constant Internal_Context := Node.Unit.Context;
+begin
+    return Get_From_File (Context, Filename, Default_Charset,
+                          Reparse => False,
+                          Rule    => Default_Grammar_Rule);
+end Example_P_Fetch_Example_Unit;

--- a/testsuite/tests/properties/invalidation_during_mmz/main.py
+++ b/testsuite/tests/properties/invalidation_during_mmz/main.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+import libfoolang
+
+
+print('main.py: Running...')
+
+ctx = libfoolang.AnalysisContext()
+u = ctx.get_from_buffer('main.txt', 'example')
+if u.diagnostics:
+    for d in u.diagnostics:
+        print(d)
+    sys.exit(1)
+
+print('root.p_mmz_prop(42) = {}'.format(u.root.p_mmz_prop(42)))
+
+try:
+    result = u.root.p_mmz_prop(0)
+except libfoolang.PropertyError:
+    result = "PropertyError"
+print('root.p_mmz_prop(0)  = {}'.format(result))
+
+print('main.py: Done.')

--- a/testsuite/tests/properties/invalidation_during_mmz/test.out
+++ b/testsuite/tests/properties/invalidation_during_mmz/test.out
@@ -1,0 +1,5 @@
+main.py: Running...
+root.p_mmz_prop(42) = 42
+root.p_mmz_prop(0)  = PropertyError
+main.py: Done.
+Done

--- a/testsuite/tests/properties/invalidation_during_mmz/test.py
+++ b/testsuite/tests/properties/invalidation_during_mmz/test.py
@@ -1,0 +1,50 @@
+"""
+Check that memoization of a property does not crash when side effects that
+invalidate the cache are triggered during the execution of that property.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from langkit.dsl import ASTNode, AnalysisUnit, T
+from langkit.expressions import (If, PropertyError, Self, Var, ignore,
+                                 langkit_property)
+from langkit.parsers import Grammar
+
+from utils import build_and_run
+
+
+class FooNode(ASTNode):
+    pass
+
+
+class Example(FooNode):
+    @langkit_property(external=True, uses_entity_info=False, uses_envs=False,
+                      return_type=AnalysisUnit)
+    def fetch_example_unit():
+        pass
+
+    @langkit_property(memoized=True, return_type=T.Int)
+    def internal_mmz_prop(i=T.Int):
+        return If(
+            i == 0,
+            PropertyError(T.Int),
+            i
+        )
+
+    @langkit_property(public=True, memoized=True, return_type=T.Int)
+    def mmz_prop(i=T.Int):
+        # Update context version by parsing a new unit
+        ignore(Var(Self.fetch_example_unit))
+
+        # Trigger a cache clear by calling another property
+        # (which will call Reset_Caches).
+        return Self.internal_mmz_prop(i)
+
+
+grammar = Grammar('main_rule')
+grammar.add_rules(
+    main_rule=Example('example'),
+)
+
+build_and_run(grammar, "main.py")
+print('Done')

--- a/testsuite/tests/properties/invalidation_during_mmz/test.yaml
+++ b/testsuite/tests/properties/invalidation_during_mmz/test.yaml
@@ -1,0 +1,1 @@
+driver: python


### PR DESCRIPTION
When the memoization map was invalidated during the execution of a memoized property,
the call to "Replace_Element" would fail with a constraint_error because the given
cursor was not valid anymore (since the memoization map was cleared in-between).

Fix this by:
 - Introducing the `Mmz_Initial_Cache_Version` value which stores the cache version
   of the current unit after the initial memoization lookup and before the execution
   of the property.
 - Adding a conditional around the update of the memoization map once the property
   has finished its execution (normally or with an exception):
    - If the cache version of the current unit has changed, the memoization map has
      been cleared and therefore the cursor is not valid anymore: forget about
      the cursor and insert a new entry in the map. This requires rebuilding the
      key because it was destroyed along the memoization map.
    - Else call `Replace_Element` as before.