### PR TITLE
Do not memoize prop. if mmz. table reset happened during its execution

### DIFF
--- a/langkit/templates/memoization_ada.mako
+++ b/langkit/templates/memoization_ada.mako
@@ -87,8 +87,7 @@ function Find_Memoized_Value
 procedure Add_Memoized_Value
   (Unit       : Internal_Unit;
    Handle     : in out Memoization_Handle;
-   Value      : Mmz_Value;
-   Create_Key : access function return Mmz_Key);
+   Value      : Mmz_Value);
 --  Insert the Handle.Key/Value entry in UNit.Memoization_Map (replacing the
 --  previous entry, if present). If the key in Handle is stale (i.e. caches
 --  were reset since it was created), recompute it using Create_Key.
@@ -305,19 +304,14 @@ end Find_Memoized_Value;
 procedure Add_Memoized_Value
   (Unit       : Internal_Unit;
    Handle     : in out Memoization_Handle;
-   Value      : Mmz_Value;
-   Create_Key : access function return Mmz_Key) is
+   Value      : Mmz_Value) is
 begin
    --  If Handle was created using a memoization map that has been since then
-   --  reset, re-create the key.
+   --  reset, do nothing: the result can be partly stale due to the event that
+   --  triggered the memoization tables reset.
+
    if Handle.Cache_Version < Unit.Cache_Version then
-      declare
-         Dummy_Value : Mmz_Value;
-         Dummy_Inserted : constant Boolean := Find_Memoized_Value
-           (Unit, Handle, Dummy_Value, Create_Key);
-      begin
-         null;
-      end;
+      return;
    end if;
 
    Unit.Memoization_Map.Replace_Element (Handle.Cur, Value);

--- a/langkit/templates/properties/def_ada.mako
+++ b/langkit/templates/properties/def_ada.mako
@@ -256,8 +256,7 @@ begin
 
          Mmz_Val := (Kind => ${property.type.memoization_kind},
                      As_${property.type.name} => Property_Result);
-         Add_Memoized_Value
-           (Self.Unit, Mmz_Handle, Mmz_Val, Create_Mmz_Key'Access);
+         Add_Memoized_Value (Self.Unit, Mmz_Handle, Mmz_Val);
          % if property.type.is_refcounted:
             Inc_Ref (Property_Result);
          % endif
@@ -301,10 +300,7 @@ exception
          % endif
 
             Add_Memoized_Value
-              (Self.Unit,
-               Mmz_Handle,
-               (Kind => Mmz_Property_Error),
-               Create_Mmz_Key'Access);
+              (Self.Unit, Mmz_Handle, (Kind => Mmz_Property_Error));
 
          % if not property.memoize_in_populate:
          end if;

--- a/testsuite/tests/properties/memoized_unit_loading/extensions/nodes/example/bodies
+++ b/testsuite/tests/properties/memoized_unit_loading/extensions/nodes/example/bodies
@@ -1,0 +1,18 @@
+--  vim: ft=ada
+
+function Example_P_Ext_Fetch_Example_Unit
+  (Node : Bare_Example) return Internal_Unit is
+begin
+   return Get_From_File
+     (Context  => Node.Unit.Context,
+      Filename => "example.txt",
+      Charset  => Default_Charset,
+      Reparse  => False,
+      Rule     => Default_Grammar_Rule);
+end Example_P_Ext_Fetch_Example_Unit;
+
+function Example_P_Ext_Unit_Count
+  (Node : Bare_Example) return Integer is
+begin
+   return Integer (Node.Unit.Context.Units.Length);
+end Example_P_Ext_Unit_Count;

--- a/testsuite/tests/properties/memoized_unit_loading/main.py
+++ b/testsuite/tests/properties/memoized_unit_loading/main.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+import libfoolang
+
+
+print('main.py: Running...')
+
+ctx = libfoolang.AnalysisContext()
+u = ctx.get_from_buffer('main.txt', 'example')
+if u.diagnostics:
+    for d in u.diagnostics:
+        print(d)
+    sys.exit(1)
+
+for i in range(3):
+    print('root.p_mmz_prop() = {}'.format(u.root.p_mmz_prop))
+
+print('main.py: Done.')

--- a/testsuite/tests/properties/memoized_unit_loading/test.out
+++ b/testsuite/tests/properties/memoized_unit_loading/test.out
@@ -1,0 +1,24 @@
+main.py: Running...
+[LANGKIT.PROPERTIES] Example.mmz_prop (<Example main.txt:1:1-1:8>):
+   [LANGKIT.PROPERTIES] Example.unit_count (<Example main.txt:1:1-1:8>):
+      [LANGKIT.PROPERTIES] Result:  1
+   [LANGKIT.PROPERTIES] Example.fetch_example_unit (<Example main.txt:1:1-1:8>):
+      [LANGKIT.PROPERTIES] Result: Internal_Unit ("example.txt")
+   [LANGKIT.PROPERTIES] Example.unit_count (<Example main.txt:1:1-1:8>):
+      [LANGKIT.PROPERTIES] Result:  2
+   [LANGKIT.PROPERTIES] Result: [ 1,  2]
+root.p_mmz_prop() = [1, 2]
+[LANGKIT.PROPERTIES] Example.mmz_prop (<Example main.txt:1:1-1:8>):
+   [LANGKIT.PROPERTIES] Example.unit_count (<Example main.txt:1:1-1:8>):
+      [LANGKIT.PROPERTIES] Result:  2
+   [LANGKIT.PROPERTIES] Example.fetch_example_unit (<Example main.txt:1:1-1:8>):
+      [LANGKIT.PROPERTIES] Result: Internal_Unit ("example.txt")
+   [LANGKIT.PROPERTIES] Example.unit_count (<Example main.txt:1:1-1:8>):
+      [LANGKIT.PROPERTIES] Result:  2
+   [LANGKIT.PROPERTIES] Result: [ 2,  2]
+root.p_mmz_prop() = [2, 2]
+[LANGKIT.PROPERTIES] Example.mmz_prop (<Example main.txt:1:1-1:8>):
+   [LANGKIT.PROPERTIES] Result: [ 2,  2]
+root.p_mmz_prop() = [2, 2]
+main.py: Done.
+Done

--- a/testsuite/tests/properties/memoized_unit_loading/test.py
+++ b/testsuite/tests/properties/memoized_unit_loading/test.py
@@ -1,0 +1,67 @@
+"""
+Check that property memoization works as expected whhen memoization table
+invalidation happens in the middle of their execution. In particular, check
+that the result of memoized properties are consistent, and would be the same as
+if properties were not memoized.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+from langkit.dsl import ASTNode, AnalysisUnit, T
+from langkit.expressions import Self, Var, ignore, langkit_property
+from langkit.parsers import Grammar
+
+from utils import build_and_run
+
+
+class FooNode(ASTNode):
+    pass
+
+
+class Example(FooNode):
+
+    # External properties
+
+    @langkit_property(external=True, uses_entity_info=False, uses_envs=False,
+                      return_type=AnalysisUnit)
+    def ext_fetch_example_unit():
+        pass
+
+    @langkit_property(external=True, uses_entity_info=False, uses_envs=False,
+                      return_type=T.Int)
+    def ext_unit_count():
+        pass
+
+    # External property wrappers (for tracing)
+
+    @langkit_property(memoized=True, activate_tracing=True)
+    def fetch_example_unit():
+        return Self.ext_fetch_example_unit
+
+    @langkit_property(memoized=True, activate_tracing=True)
+    def unit_count():
+        return Self.ext_unit_count
+
+    # Test entry point
+
+    @langkit_property(public=True, memoized=True, activate_tracing=True)
+    def mmz_prop():
+        # Both calls to unit_count are memoized, but when called for the first
+        # time, the first one's result will be different from the second one.
+        before = Var([Self.unit_count])
+
+        # Update context version by parsing a new unit
+        ignore(Var(Self.fetch_example_unit))
+
+        after = Var([Self.unit_count])
+
+        return before.concat(after)
+
+
+grammar = Grammar('main_rule')
+grammar.add_rules(
+    main_rule=Example('example'),
+)
+
+build_and_run(grammar, "main.py")
+print('Done')

--- a/testsuite/tests/properties/memoized_unit_loading/test.yaml
+++ b/testsuite/tests/properties/memoized_unit_loading/test.yaml
@@ -1,0 +1,1 @@
+driver: python


### PR DESCRIPTION
If memoization table reset happens in the middle of the exceution of a
property, then computings that happened before that reset could change
in later calls, so it is not sound to keep the result of that property
execution.