### PR TITLE
Minor: clean build space for lib*lang before building

### DIFF
--- a/scripts/manage.sh
+++ b/scripts/manage.sh
@@ -5,12 +5,26 @@ LANGKIT_ROOT=`dirname $0`"/.."
 cd "$LANGKIT_ROOT"
 
 make () {
+
+    # We need to clean the build space of the langkit libraries we depend
+    # upon before we run langkit again. Else, if we installed a newer version
+    # of GNAT since those libraries were built, what will happen is that:
+    #
+    # 1. Langkit will try loading them.
+    # 2. This will cause an uncaught exception trying to load some so from the
+    #    compiler, preventing langkit to run.
+    # 3. Langkit cannot be used to recompile libpythonlang and liblktlang to
+    #    newer versions.
+    rm contrib/python/build -rf
+    rm contrib/lkt/build -rf
+
     (
         cd "contrib/python"
         ./manage.py make -P
     )
     (
         cd "contrib/lkt"
+        rm build -rf
         ./manage.py make -P
     )
 }


### PR DESCRIPTION
This ensures that if the version of GNAT has changed, we won't get an
uncaught exception from out of date libraries.