### PR TITLE
Try to fix MacOS build

### DIFF
--- a/langkit/libmanage.py
+++ b/langkit/libmanage.py
@@ -1183,6 +1183,7 @@ class ManageScript(object):
         for lib in libs:
             add_path('LIBRARY_PATH', lib_subdir(lib, 'static'))
             add_path('LD_LIBRARY_PATH', lib_subdir(lib, 'relocatable'))
+            add_path('DYLD_LIBRARY_PATH', lib_subdir(lib, 'relocatable'))
             add_path('PATH', lib_subdir(lib, 'relocatable'))
 
         add_path('GPR_PROJECT_PATH', self.dirs.build_dir('lib', 'gnat'))


### PR DESCRIPTION
Mac OS X uses DYLD_LIBRARY_PATH instead of LD_LIBRARY_PATH in Linux. This patch helps me build Libadalang on Mac OS using Github Actions and python3.