### PR TITLE
Expose filename member for analysis unit in Ocaml bindings

### DIFF
--- a/langkit/templates/ocaml_api/module_sig_ocaml.mako
+++ b/langkit/templates/ocaml_api/module_sig_ocaml.mako
@@ -164,6 +164,9 @@ and AnalysisUnit : sig
    * Diagnostics for this unit.
    *)
 
+  val filename : t -> string
+  ${ocaml_doc('langkit.unit_filename', 1)}
+
   val reparse : ?charset:string -> ?buffer:string -> t -> unit
   ${ocaml_doc('langkit.unit_reparse_generic', 1)}
 

--- a/langkit/templates/ocaml_api/struct_types_ocaml.mako
+++ b/langkit/templates/ocaml_api/struct_types_ocaml.mako
@@ -120,6 +120,8 @@ module AnalysisUnitStruct : sig
 
   val unit_diagnostic : t -> int -> Diagnostic.t ptr -> int
 
+  val unit_filename : t -> char ptr
+
   val unit_reparse_from_file : t -> string -> int
 
   val unit_reparse_from_buffer :
@@ -148,6 +150,10 @@ end = struct
   let unit_diagnostic = foreign ~from:c_lib
     "${capi.get_name('unit_diagnostic')}"
     (c_type @-> int @-> ptr Diagnostic.c_type @-> raisable int)
+
+  let unit_filename = foreign ~from:c_lib
+    "${capi.get_name('unit_filename')}"
+    (c_type @-> raisable (ptr char))
 
   let unit_reparse_from_file = foreign ~from:c_lib
     "${capi.get_name('unit_reparse_from_file')}"

--- a/testsuite/tests/ocaml_api/general/main.ml
+++ b/testsuite/tests/ocaml_api/general/main.ml
@@ -41,6 +41,7 @@ let pp_token_info fmt with_trivia =
   print_exit_if_diags u ;
   let root = root_exn u in
   let first_token = AnalysisUnit.first_token u in
+  let first_token_kind_name = Token.kind_name first_token in
   let last_token = AnalysisUnit.last_token u in
   let token_start = FooNode.token_start root in
   let token_end = FooNode.token_end root in
@@ -48,10 +49,10 @@ let pp_token_info fmt with_trivia =
   let trivia_count = AnalysisUnit.trivia_count u in
   Format.fprintf fmt "@[<v>@[<v 2>root text=@ %S@]@ @]" (FooNode.text root) ;
   Format.fprintf fmt
-    "@[<v>first_token = %S@ last_token = %S@ token_start = %S@ token_end = \
-     %S@ token_count = %d@ trivia_count = %d@]"
-    first_token.text last_token.text token_start.text token_end.text
-    token_count trivia_count
+    "@[<v>first_token = %S@ first_token_kind_name = %S@ last_token = %S@ \
+     token_start = %S@ token_end = %S@ token_count = %d@ trivia_count = %d@]"
+    first_token.text first_token_kind_name last_token.text token_start.text
+    token_end.text token_count trivia_count
 
 let test_diagnostics () =
   (* Diagnostics *)
@@ -63,6 +64,14 @@ let test_diagnostics () =
   (* Parsing error *)
   let u = AnalysisContext.get_from_buffer ctx "foo.txt" "var identifier" in
   Format.printf "%a" pp_diags (AnalysisUnit.diagnostics u) ;
+  Format.printf "@[<v>=========================@ @ @]"
+
+let test_unit_filename () =
+  Format.printf "@[<v>======UNIT_FILENAME=========@ @]" ;
+  let ctx = AnalysisContext.create () in
+  let u = AnalysisContext.get_from_file ctx "foo.txt" in
+  let filename = Filename.basename (AnalysisUnit.filename u) in
+  Format.printf "@[<v>Unit corresponding to file %s@ @]" filename ;
   Format.printf "@[<v>=========================@ @ @]"
 
 let test_token () =
@@ -431,6 +440,7 @@ let test_struct () =
 
 let () =
   test_diagnostics () ;
+  test_unit_filename () ;
   test_token () ;
   test_node () ;
   test_parent () ;

--- a/testsuite/tests/ocaml_api/general/test.out
+++ b/testsuite/tests/ocaml_api/general/test.out
@@ -3,11 +3,16 @@ Cannot read unknown
 Expected '(', got Identifier
 =========================
 
+======UNIT_FILENAME=========
+Unit corresponding to file foo.txt
+=========================
+
 =======TOKEN FUNCTIONS=======
 With trivia:
   root text=
     "null example var (null example null) example null"
   first_token = "null"
+  first_token_kind_name = "Null_Tok"
   last_token = ""
   token_start = "null"
   token_end = "null"
@@ -18,6 +23,7 @@ Without trivia:
   root text=
     "null example var (null example null) example null"
   first_token = "null"
+  first_token_kind_name = "Null_Tok"
   last_token = ""
   token_start = "null"
   token_end = "null"


### PR DESCRIPTION
This PR exposes the filename attribute of the analysis units in the Ocaml bindings.
This also fixes memory leaks on the function token_kind_name in module Token.