### PR TITLE
Add typed lookup utility for Ocaml bindings

### DIFF
--- a/langkit/templates/ocaml_api/module_ocaml.mako
+++ b/langkit/templates/ocaml_api/module_ocaml.mako
@@ -1134,6 +1134,24 @@ let ${ocaml_api.field_name(field)}
     let rec aux node = p node && for_all_fields aux node in
     aux (node :> ${root_entity_type})
 
+  let lookup_with_kind : type a. a node -> [< ${root_entity_type}] -> Sloc.t -> a option =
+    fun node_type node sloc ->
+      let lookup_res = lookup node sloc in
+      let rec aux : a node -> [< ${root_entity_type}] -> a option =
+        fun node_type node -> 
+        match node_type, node with
+      %for astnode in ctx.astnode_types:
+        | ${ocaml_api.node_name(astnode)}
+          , (#${ocaml_api.type_public_name(astnode)} as node) ->
+          Some node
+      %endfor
+        | _ -> (match parent node with
+                | Some parent_node -> aux node_type parent_node
+                | _ -> None) in
+    match lookup_res with
+      | Some node -> aux node_type node
+      | _ -> None
+
   let as_a : type a. a node -> [< ${root_entity_type} ] -> a option =
    fun node_type node ->
     match node_type, (node :> ${root_entity_type}) with

--- a/langkit/templates/ocaml_api/module_sig_ocaml.mako
+++ b/langkit/templates/ocaml_api/module_sig_ocaml.mako
@@ -362,6 +362,12 @@ module ${ocaml_api.node_name(astnode)} : sig
    * predicate is evaluated to true for all nodes.
    *)
 
+  val lookup_with_kind : 'a node -> [< ${root_entity_type}] -> Sloc.t -> 'a option
+  (**
+   * Given the kind of a node, a source location and a node, return the deepest node
+   * containing the source location and of the right kind. Returns None if there is no match.
+   *)
+
   val as_a : 'a node -> [< ${root_entity_type} ] -> 'a option
   (**
    * Given the kind of a node, try to cast the given node to this kind. Return

--- a/testsuite/tests/ocaml_api/general/main.ml
+++ b/testsuite/tests/ocaml_api/general/main.ml
@@ -396,17 +396,17 @@ let test_enum () =
   in
   let print c =
     Format.printf
-      "@[<v>@[color: %a;@ same_color: %a;@ same_color_dflt: %a@]@ @]"
-      pp_color c
-      pp_color (FooNode.p_same_color root c)
-      pp_color (FooNode.p_same_color_dflt root ~c:c)
+      "@[<v>@[color: %a;@ same_color: %a;@ same_color_dflt: %a@]@ @]" pp_color
+      c pp_color
+      (FooNode.p_same_color root c)
+      pp_color
+      (FooNode.p_same_color_dflt root ~c)
   in
   print Red ;
   print Green ;
   print Blue ;
-  Format.printf
-    "@[<v>@[same_color_dflt: %a@]@ @]"
-    pp_color (FooNode.p_same_color_dflt root) ;
+  Format.printf "@[<v>@[same_color_dflt: %a@]@ @]" pp_color
+    (FooNode.p_same_color_dflt root) ;
   Format.printf "@[<v>=================@ @ @]"
 
 let test_big_int () =

--- a/testsuite/tests/ocaml_api/general/main.ml
+++ b/testsuite/tests/ocaml_api/general/main.ml
@@ -217,6 +217,34 @@ let test_node () =
     (FooNode.for_all aux root) ;
   Format.printf "@[<v>============================@ @ @]"
 
+let test_lookup_with_kind () =
+  Format.printf "@[<v>========== LOOKUP ==========@ @]" ;
+  let ctx = AnalysisContext.create () in
+  let u = AnalysisContext.get_from_file ~reparse:true ctx "foo.txt" in
+  print_exit_if_diags u ;
+  let root = root_exn u in
+  let lookup_1 : Sequence.t option =
+    FooNode.lookup_with_kind Sequence root {Sloc.line= 1; Sloc.column= 25}
+  in
+  ( match lookup_1 with
+  | Some node ->
+      Format.printf "@[<v>Lookup at loc 1:25 and kind `Sequence` found %a@ @]"
+        pp_image node
+  | _ ->
+      Format.printf
+        "@[<v>Lookup at loc 1:25 and kind `Sequence` returned None.@ @]" ) ;
+  let lookup_2 =
+    FooNode.lookup_with_kind Sequence root {Sloc.line= 2; Sloc.column= 25}
+  in
+  ( match lookup_2 with
+  | Some node ->
+      Format.printf "@[<v>Lookup at loc 2:25 and kind `Sequence` found %a@ @]"
+        pp_image node
+  | _ ->
+      Format.printf
+        "@[<v>Lookup at loc 2:25 and kind `Sequence` returned None.@ @]" ) ;
+  Format.printf "@[<v>============================@ @ @]"
+
 let test_parent () =
   Format.printf "@[<v>=======PARENT(S)=======@ @]" ;
   let ctx = AnalysisContext.create () in
@@ -443,6 +471,7 @@ let () =
   test_unit_filename () ;
   test_token () ;
   test_node () ;
+  test_lookup_with_kind () ;
   test_parent () ;
   test_siblings () ;
   test_array () ;

--- a/testsuite/tests/ocaml_api/general/test.out
+++ b/testsuite/tests/ocaml_api/general/test.out
@@ -288,6 +288,11 @@ Iter:
 proposition (for all node n1. exists node n2. n1 = n2) is true
 ============================
 
+========== LOOKUP ==========
+Lookup at loc 1:25 and kind `Sequence` found <Sequence foo.txt:1:19-1:36>
+Lookup at loc 2:25 and kind `Sequence` returned None.
+============================
+
 =======PARENT(S)=======
 <Sequence foo.txt:1:1-1:50> parents:
   <Sequence foo.txt:1:1-1:50>


### PR DESCRIPTION
This new utility lets a user lookup the deepest node of a given type
containing the specified source location. The returned node is of
the specified type if found, None otherwise.