### PR TITLE
Fix Windows build by using an executable with subprocess calls

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -44,7 +44,10 @@ def setenv(args: Namespace) -> None:
     Setenv for langkit.
     """
     for cwd in (LKT_LIB_ROOT, PYTHON_LIB_ROOT):
-        subprocess.check_call(["./manage.py", "setenv"], cwd=cwd)
+        subprocess.check_call(
+            [sys.executable, "./manage.py", "setenv"],
+            cwd=cwd
+        )
 
 
 def make(args: Namespace) -> None:
@@ -65,12 +68,12 @@ def make(args: Namespace) -> None:
     shutil.rmtree(PYTHON_LIB_ROOT / 'build', ignore_errors=True)
 
     m1 = subprocess.Popen(
-        ["./manage.py", "-Dgnu-full", "make", "-P",
+        [sys.executable, "./manage.py", "-Dgnu-full", "make", "-P",
          "--disable-warning", "undocumented-nodes"],
         cwd=PYTHON_LIB_ROOT
     )
     m2 = subprocess.Popen(
-        ["./manage.py", "-Dgnu-full", "make", "-P"],
+        [sys.executable, "./manage.py", "-Dgnu-full", "make", "-P"],
         cwd=LKT_LIB_ROOT
     )
     m1.wait()
@@ -84,7 +87,8 @@ def test(args: Namespace, remaining_args: List[str]) -> None:
     Run langkit's testsuite.
     """
     subprocess.check_call(
-        ['python3', str(LANGKIT_ROOT / 'testsuite' / 'testsuite.py'), '-Edtmp']
+        [sys.executable, str(LANGKIT_ROOT / 'testsuite' / 'testsuite.py'),
+         '-Edtmp']
         + remaining_args
     )
 


### PR DESCRIPTION
Got the following error when trying to build on Windows

```
Traceback (most recent call last):
  File "manage.py", line 103, in <module>
    args.func(args, unknown_args)
  File "manage.py", line 35, in wrapper
    fn(args)
  File "manage.py", line 67, in make
    m1 = subprocess.Popen(
  File "C:\Python38\lib\subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Python38\lib\subprocess.py", line 1308, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
OSError: [WinError 193] %1 is not a valid Win32 application
```

Windows requires an executable as the first argument, can't get away with relying on a shebang here!

Added the missing executables to the calls, and made one existing one more consistent.