### PR TITLE
Langkit_Support.Symbols: fix Get_Symbol for null symbols

### DIFF
--- a/langkit/support/langkit_support-symbols.adb
+++ b/langkit/support/langkit_support-symbols.adb
@@ -135,7 +135,11 @@ package body Langkit_Support.Symbols is
    function Get_Symbol
      (Self : Symbol_Table; TS : Thin_Symbol) return Symbol_Type is
    begin
-      return Self.Symbols.Get (Positive (TS));
+      if TS = No_Thin_Symbol then
+         return null;
+      else
+         return Self.Symbols.Get (Positive (TS));
+      end if;
    end Get_Symbol;
 
 end Langkit_Support.Symbols;

--- a/testsuite/tests/properties/symbol/extensions/src/pkg.adb
+++ b/testsuite/tests/properties/symbol/extensions/src/pkg.adb
@@ -1,0 +1,13 @@
+package body Pkg is
+
+   ------------------
+   -- Canonicalize --
+   ------------------
+
+   function Canonicalize (Name : Text_Type) return Symbolization_Result is
+      pragma Unreferenced (Name);
+   begin
+      return Create_Error ("no symbol allowed");
+   end Canonicalize;
+
+end Pkg;

--- a/testsuite/tests/properties/symbol/extensions/src/pkg.ads
+++ b/testsuite/tests/properties/symbol/extensions/src/pkg.ads
@@ -1,0 +1,8 @@
+with Langkit_Support.Text; use Langkit_Support.Text;
+with Libfoolang.Common;    use Libfoolang.Common;
+
+package Pkg is
+
+   function Canonicalize (Name : Text_Type) return Symbolization_Result;
+
+end Pkg;

--- a/testsuite/tests/properties/symbol/main.py
+++ b/testsuite/tests/properties/symbol/main.py
@@ -12,11 +12,11 @@ if u.diagnostics:
         print(d)
     sys.exit(1)
 
-try:
-    result = u.root.p_prop(None)
-except libfoolang.PropertyError as exc:
-    result = '<{}: {}>'.format(type(exc).__name__, exc)
-
-print('p_prop(None) = {}'.format(result))
+for n in (None, u.root):
+    try:
+        result = libfoolang._py2to3.text_repr(u.root.p_prop(n))
+    except libfoolang.PropertyError as exc:
+        result = '<{}: {}>'.format(type(exc).__name__, exc)
+    print('p_prop({}) = {}'.format(n, result))
 
 print('main.py: Done.')

--- a/testsuite/tests/properties/symbol/test.out
+++ b/testsuite/tests/properties/symbol/test.out
@@ -1,4 +1,5 @@
 main.py: Running...
 p_prop(None) = <PropertyError: cannot get the symbol of a null node>
+p_prop(<Example main.txt:1:1-1:8>) = ''
 main.py: Done.
 Done

--- a/testsuite/tests/properties/symbol/test.py
+++ b/testsuite/tests/properties/symbol/test.py
@@ -1,7 +1,9 @@
 """
-Test that ".symbol" raises a property error on null nodes.
+Test that ".symbol" raises a property error on null nodes or when symbol
+canonicalization fails.
 """
 
+from langkit.compile_context import LibraryEntity
 from langkit.dsl import ASTNode, T
 from langkit.expressions import langkit_property
 
@@ -19,5 +21,6 @@ class Example(FooNode):
     token_node = True
 
 
-build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py')
+build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py',
+              symbol_canonicalizer=LibraryEntity('Pkg', 'Canonicalize'))
 print('Done')


### PR DESCRIPTION
When symbol canonicalization fails, $.Lexer_Implementation.Force_Symbol
calls Get_Symbol passing to it No_Thin_Symbol, so Get_Symbol needs to
support this case.
