### PR TITLE
To_Unbounded_Text (S: String)

### DIFF
--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -4234,7 +4234,7 @@ class SymbolType(CompiledType):
         ])
 
     def to_public_expr(self, internal_expr):
-        return 'To_Unbounded_Text (Image ({}))'.format(internal_expr)
+        return "To_Unbounded_Text (Text_Type'(Image ({})))".format(internal_expr)
 
     def to_internal_expr(self, public_expr, context):
         return 'Lookup_Symbol ({}, To_Text ({}))'.format(context, public_expr)

--- a/support/langkit_support-text.adb
+++ b/support/langkit_support-text.adb
@@ -65,6 +65,15 @@ package body Langkit_Support.Text is
       return Result;
    end To_Text;
 
+   -----------------------
+   -- To_Unbounded_Text --
+   -----------------------
+
+   function To_Unbounded_Text (S : String) return Unbounded_Text_Type is
+   begin
+      return To_Unbounded_Text (To_Text (S));
+   end To_Unbounded_Text;
+
    -----------
    -- Image --
    -----------

--- a/support/langkit_support-text.ads
+++ b/support/langkit_support-text.ads
@@ -48,6 +48,8 @@ package Langkit_Support.Text is
    function To_Unbounded_Text (T : Text_Type) return Unbounded_Text_Type
       renames Ada.Strings.Wide_Wide_Unbounded.To_Unbounded_Wide_Wide_String;
 
+   function To_Unbounded_Text (S : String) return Unbounded_Text_Type;
+
    function Image
      (T : Text_Type; With_Quotes : Boolean := False)
       return String;


### PR DESCRIPTION
Simple overloading of `To_Unbounded_Text` to accept a `String` argument. The implementation is very straightforwards but may be a bit lackluster performance-wise.

By overloading the `To_Unbounded_Text` to accept `String`, calls to` To_Unbounded_String ( F ) `can become ambiguous, if `F` is an overloaded function that can return both `String` and `Text_Type` ( `Wide_Wide_String`).
The solution in that case is to use the `Text_Type` qualifier, as the `Text_Type` version is more efficient (it is already Unicode).