### PR TITLE
Remove recursive modules from OCaml bindings

### DIFF
--- a/langkit/emitter.py
+++ b/langkit/emitter.py
@@ -688,6 +688,12 @@ class Emitter:
             os.mkdir(self.ocaml_dir)
 
         with names.camel:
+            # Write an empty ocamlformat file so we can call ocamlformat
+            write_source_file(
+                os.path.join(self.ocaml_dir, '.ocamlformat'),
+                ''
+            )
+
             ctx = get_context()
             code = ctx.render_template(
                 "ocaml_api/module_ocaml",

--- a/langkit/ocaml_api.py
+++ b/langkit/ocaml_api.py
@@ -700,19 +700,6 @@ class OCamlAPISettings(AbstractAPISettings):
 
         return topo
 
-    def escape_ocaml_keyword(self, string: str) -> str:
-        """
-        Return a replacement for the given string if the string is an OCaml
-        keyword that cannot appear as an identifier.
-
-        :param string: The string we want to replace if necessary.
-        """
-        replacement = {
-            "val": "value",
-            "constraint": "constr"
-        }
-        return replacement.get(string, string)
-
     def field_name(self, field: ct.Field) -> str:
         """
         Given a Field instance, return the name of the field to be used for an
@@ -720,4 +707,7 @@ class OCamlAPISettings(AbstractAPISettings):
 
         :param field: The field for which we want it's name.
         """
-        return self.escape_ocaml_keyword(field.api_name.lower)
+        name = field.api_name.lower
+
+        # Add _ to the name if it is an ocaml keyword
+        return "{}_".format(name) if name in ocaml_keywords else name

--- a/langkit/templates/ocaml_api/array_types_ocaml.mako
+++ b/langkit/templates/ocaml_api/array_types_ocaml.mako
@@ -39,13 +39,13 @@ end
    % endif
 
    % if ocaml_api.wrap_requires_context(cls):
-  val wrap : AnalysisContext.t -> ${ocaml_api.c_value_type(cls)} -> t
+  val wrap : analysis_context -> ${ocaml_api.c_value_type(cls)} -> t
    % else:
   val wrap : ${ocaml_api.c_value_type(cls)} -> t
    % endif
 
    % if cls.conversion_requires_context:
-  val unwrap : AnalysisContext.t -> t -> ${ocaml_api.c_value_type(cls)}
+  val unwrap : analysis_context -> t -> ${ocaml_api.c_value_type(cls)}
    % else:
   val unwrap : t -> ${ocaml_api.c_value_type(cls)}
    % endif
@@ -59,7 +59,7 @@ end
    % endif
 
    % if ocaml_api.wrap_requires_context(cls):
-  let wrap context c_value_ptr =
+  let wrap (context : analysis_context) c_value_ptr =
    % else:
   let wrap c_value_ptr =
    % endif
@@ -95,7 +95,7 @@ end
     result
 
    % if cls.conversion_requires_context:
-  let unwrap context value =
+  let unwrap (context : analysis_context) value =
    % else:
   let unwrap value =
    % endif
@@ -109,7 +109,7 @@ end
    % endif
     let items = result |-> ${ocaml_api.struct_name(cls)}.items in
    % if cls.conversion_requires_context:
-    let c_context = context.AnalysisContext.c_value in
+    let c_context = context.c_value in
    % endif
    % if cls.is_string_type:
     let i = ref 0 in

--- a/langkit/templates/ocaml_api/module_sig_ocaml.mako
+++ b/langkit/templates/ocaml_api/module_sig_ocaml.mako
@@ -139,24 +139,30 @@ module UnitProvider : sig
   )}
 end
 
-module rec Entity : sig
-  type t
+type analysis_context
 
-  val info : t -> ${ocaml_api.type_public_name(T.entity_info)}
-end
+and ${ocaml_api.type_public_name(T.AnalysisUnit)}
+
+and entity
+
+${struct_types.ocaml_fields(T.entity_info, rec=True)}
+
+${struct_types.ocaml_fields(T.env_md, rec=True)}
 
 % for astnode in ctx.astnode_types:
-and ${ocaml_api.module_name(astnode)} : sig
-
-  ${astnode_types.ast_type(astnode)}
-
-end
+  ${astnode_types.sig(astnode)}
 % endfor
 
-and AnalysisUnit : sig
+module Entity : sig
+  type t = entity
+
+  val info : t -> entity_info
+end
+
+module AnalysisUnit : sig
   ${ocaml_doc('langkit.analysis_unit_type', 1)}
 
-  type t
+  type t = analysis_unit
 
   val root : t -> ${root_entity_type} option
   ${ocaml_doc('langkit.unit_root', 1)}
@@ -187,10 +193,10 @@ and AnalysisUnit : sig
   ${token_iterator.sig("t")}
 end
 
-and AnalysisContext : sig
+module AnalysisContext : sig
   ${ocaml_doc('langkit.analysis_context_type', 1)}
 
-  type t
+  type t = analysis_context
 
   val create :
     ?charset:string
@@ -221,13 +227,12 @@ and AnalysisContext : sig
 end
 
 % for struct_type in ctx.struct_types:
-   % if not struct_type.is_entity_type:
-      % if struct_type is T.entity_info:
-   ${struct_types.public_sig(struct_type)}
-      % elif struct_type is T.env_md:
-   ${struct_types.public_sig(struct_type)}
-      % elif struct_type.exposed:
-   ${struct_types.public_sig(struct_type)}
+   % if struct_type not in [T.AnalysisUnit, ocaml_api.AnalysisContext,\
+                            T.Symbol, T.entity_info, T.env_md]:
+      % if not struct_type.is_entity_type:
+         % if struct_type.exposed:
+${struct_types.public_sig(struct_type)}
+         % endif
       % endif
    % endif
 % endfor


### PR DESCRIPTION
Since we can have hundreds of AST nodes in a langkit hierarchy, using recursive modules to represent them can cause stack overflows at compilation. Change the strategy of emitting ocaml bindings to not emit recursive modules.