### PR TITLE
U607-013: Introduce strict root_node."=" primitive

### DIFF
--- a/langkit/templates/pkg_analysis_body_ada.mako
+++ b/langkit/templates/pkg_analysis_body_ada.mako
@@ -697,6 +697,17 @@ package body ${ada_lib_name}.Analysis is
    -- "=" --
    ---------
 
+   function "=" (L, R : ${root_entity.api_name}) return Boolean is
+   begin
+      Check_Safety_Net (L);
+      Check_Safety_Net (R);
+      return Compare_Entity (L.Internal, R.Internal);
+   end "=";
+
+   ---------
+   -- "=" --
+   ---------
+
    function "=" (L, R : ${root_entity.api_name}'Class) return Boolean is
    begin
       Check_Safety_Net (L);

--- a/langkit/templates/pkg_analysis_spec_ada.mako
+++ b/langkit/templates/pkg_analysis_spec_ada.mako
@@ -66,7 +66,13 @@ package ${ada_lib_name}.Analysis is
       % if e.is_root_type:
       type ${e.api_name} is tagged private;
       ${ada_doc('langkit.node_type', 6)}
-      --
+
+      function "=" (L, R : ${root_entity.api_name}) return Boolean;
+      --  Return whether ``L`` and ``R`` designate the same node.
+
+      function Hash
+        (Node : ${root_entity.api_name}) return Ada.Containers.Hash_Type;
+      --  Generic hash function, to be used for nodes as keys in hash tables
       % else:
       type ${e.api_name} is new ${e.base.api_name} with private
       % if e.element_type.is_root_list_type:
@@ -103,7 +109,9 @@ package ${ada_lib_name}.Analysis is
    ${ada_doc('langkit.node_is_synthetic', 3)}
 
    function "=" (L, R : ${root_entity.api_name}'Class) return Boolean;
-   --  Return whether ``L`` and ``R`` designate the same node
+   --  Return whether ``L`` and ``R`` designate the same node. We have a
+   --  classwide equality to be able to compare nodes from the same type
+   --  hierarchy but with different types.
 
    function Image (Node : ${root_entity.api_name}'Class) return String;
    --  Return a short string describing ``Node``, or None" if ``Node.Is_Null``
@@ -669,10 +677,6 @@ package ${ada_lib_name}.Analysis is
         (Node : ${root_entity.api_name}'Class) return ${e.api_name};
       --% no-document: True
    % endfor
-
-   function Hash
-     (Node : ${root_entity.api_name}) return Ada.Containers.Hash_Type;
-   --  Generic hash function, to be used for nodes as keys in hash tables
    pragma Warnings (On, "defined after private extension");
 
 private

--- a/testsuite/tests/ada_api/general/expected_concrete_syntax.lkt
+++ b/testsuite/tests/ada_api/general/expected_concrete_syntax.lkt
@@ -8,6 +8,14 @@ grammar foo_grammar {
 }
 
 @abstract class FooNode : Node {
+
+    ## Return an entity for Self with some metadata set. Used to check
+    ## equality in the Ada API (see main.adb).
+    @export fun set_dummy (): FooNode = FooNode(
+        node=self.node, info=EntityInfo(
+            md=Metadata(dummy=true), rebindings=self.info.rebindings, from_rebound=self.info.from_rebound
+        )
+    )
 }
 
 class Decl : FooNode {

--- a/testsuite/tests/ada_api/general/test.out
+++ b/testsuite/tests/ada_api/general/test.out
@@ -49,5 +49,9 @@ Last child index =  0
 First child = None
 Last child = None
 
+Testing generic container instantiation's node equality
+=======================================================
+
+Element already in set
 main.adb: Done.
 Done

--- a/testsuite/tests/ada_api/general/test.py
+++ b/testsuite/tests/ada_api/general/test.py
@@ -2,13 +2,37 @@
 Check that the Children_And_Trivia function works as expected.
 """
 
-from langkit.dsl import ASTNode, Field
+from langkit.dsl import (
+    ASTNode, Field, UserField, env_metadata, Struct, Bool, T
+)
+from langkit.expressions import langkit_property, Entity
 
 from utils import build_and_run
 
 
+@env_metadata
+class Metadata(Struct):
+    dummy = UserField(Bool)
+
+
 class FooNode(ASTNode):
-    pass
+
+    @langkit_property(return_type=T.FooNode.entity, public=True)
+    def set_dummy():
+        """
+        Return an entity for Self with some metadata set. Used to check
+        equality in the Ada API (see main.adb).
+        """
+        return T.FooNode.entity.new(
+            node=Entity.node,
+            info=T.entity_info.new(
+                md=Metadata.new(
+                    dummy=True
+                ),
+                rebindings=Entity.info.rebindings,
+                from_rebound=Entity.info.from_rebound
+            )
+        )
 
 
 class DeclError(FooNode):
@@ -26,5 +50,5 @@ class Decl(FooNode):
 
 
 build_and_run(lkt_file='expected_concrete_syntax.lkt', ada_main='main.adb',
-              types_from_lkt=True)
+              types_from_lkt=False)
 print('Done')


### PR DESCRIPTION
So that, in the Ada API, containers instantiations requiring an "="
function don't use the built-in equality operator, and other cases where
strict equality overriding is necessary.

Also make "Node.Hash" a primitive, so that there exists a version for
derived types out of the box.