### PR TITLE
RA22-015: Fix call decl/type resolution

### DIFF
--- a/contrib/lkt/language/parser.py
+++ b/contrib/lkt/language/parser.py
@@ -2098,11 +2098,17 @@ class SimpleTypeRef(TypeRef):
 
     @langkit_property(return_type=T.SemanticResult.array)
     def check_correctness_pre():
+
         d = Var(Entity.type_name.referenced_decl)
+
         return d.result_ref.then(
-            lambda d: d.cast(T.TypeDecl).then(
-                lambda _: No(T.SemanticResult.array),
-                default_val=Entity.error(S("Invalid type reference")).singleton
+            lambda d: d.match(
+                # The type ref references a type decl: return no error
+                lambda _=T.TypeDecl: No(T.SemanticResult.array),
+
+                # Not a type decl: return an error that the type reference is
+                # invalid.
+                lambda _: [Entity.error(S("Invalid type reference"))]
             )
         )
 

--- a/contrib/lkt/language/parser.py
+++ b/contrib/lkt/language/parser.py
@@ -2579,6 +2579,23 @@ class CallExpr(Expr):
             ),
             # If not a generic decl, fall back on the initially found decl
             default_val=called_decl
+        )._.match(
+            # Here, if we found a declaration but it's not one of the
+            # statically callable declarations (FunDecl or TypeDecl), we
+            # return nothing, even though we might be able to statically
+            # determine a declaration, like in the example below::
+            #
+            #    val a: (Int) -> Int = null
+            #    val b: Int = a(12)
+            #
+            # That's because in language semantic terms, the actual called
+            # function is determined dynamically in the above case.
+            #
+            # TODO: Maybe introduce a base class for statically callable
+            # declarations, so we don't have to do this ugly match.
+            lambda t=TypeDecl: t,
+            lambda f=FunDecl: f,
+            lambda _: No(T.Decl.entity)
         )
 
     @langkit_property()

--- a/contrib/lkt/language/prelude.lkt
+++ b/contrib/lkt/language/prelude.lkt
@@ -35,7 +35,7 @@ trait Iterator {
 
 @builtin generic[T]
 struct Array implements Sized, Indexable[T], Iterator[T] {
-    @builtin @property fun to_iterator(): Iterator[T]
+    @builtin fun to_iterator(): Iterator[T]
 }
 
 @builtin generic[T]

--- a/testsuite/tests/contrib/lkt_semantic/advanced_calls/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/advanced_calls/test.lkt
@@ -1,0 +1,19 @@
+class MyCallable {
+    fun __call__(a: Int): Bool
+}
+
+class RecursiveCallable {
+    fun __call__(a: Int): RecursiveCallable
+}
+
+class A {
+    @property
+    fun pouet(): (Int) -> Bool
+
+    fun callable_array(): Array[MyCallable]
+
+    fun test(): Bool = self.pouet(12)
+    fun test2(): Bool = MyCallable()(12)
+    fun test3(): Bool = self.callable_array()(12)(12)
+    fun test4(): RecursiveCallable = RecursiveCallable()(12)(12)(12)(12)(12)(12)(12)(12)(12)(12)(12)(12)(12)(12)
+}

--- a/testsuite/tests/contrib/lkt_semantic/advanced_calls/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/advanced_calls/test.out
@@ -1,0 +1,191 @@
+Resolving test.lkt
+==================
+Id   <RefId "Int" test.lkt:2:21-2:24>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "Bool" test.lkt:2:27-2:31>
+     references <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "Int" test.lkt:6:21-6:24>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "RecursiveCallable" test.lkt:6:27-6:44>
+     references <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Id   <RefId "Int" test.lkt:11:19-11:22>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "Bool" test.lkt:11:27-11:31>
+     references <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "Array" test.lkt:13:27-13:32>
+     references <GenericDecl prelude: "Array">
+
+Id   <RefId "MyCallable" test.lkt:13:33-13:43>
+     references <ClassDecl "MyCallable" test.lkt:1:1-3:2>
+
+Id   <RefId "Bool" test.lkt:15:17-15:21>
+     references <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "self" test.lkt:15:24-15:28>
+     references <SelfDecl "self" test.lkt:9:1-19:2>
+
+Expr <RefId "self" test.lkt:15:24-15:28>
+     has type <ClassDecl "A" test.lkt:9:1-19:2>
+
+Id   <RefId "pouet" test.lkt:15:29-15:34>
+     references <FunDecl "pouet" test.lkt:11:5-11:31>
+
+Expr <RefId "pouet" test.lkt:15:29-15:34>
+     has type <FunctionType prelude: "(Int) -> Bool">
+
+Expr <DotExpr test.lkt:15:24-15:34>
+     has type <FunctionType prelude: "(Int) -> Bool">
+
+Expr <NumLit test.lkt:15:35-15:37>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:15:24-15:38>
+     has type <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "Bool" test.lkt:16:18-16:22>
+     references <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "MyCallable" test.lkt:16:25-16:35>
+     references <ClassDecl "MyCallable" test.lkt:1:1-3:2>
+
+Expr <CallExpr test.lkt:16:25-16:37>
+     has type <ClassDecl "MyCallable" test.lkt:1:1-3:2>
+
+Expr <NumLit test.lkt:16:38-16:40>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:16:25-16:41>
+     has type <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "Bool" test.lkt:17:18-17:22>
+     references <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "self" test.lkt:17:25-17:29>
+     references <SelfDecl "self" test.lkt:9:1-19:2>
+
+Expr <RefId "self" test.lkt:17:25-17:29>
+     has type <ClassDecl "A" test.lkt:9:1-19:2>
+
+Id   <RefId "callable_array" test.lkt:17:30-17:44>
+     references <FunDecl "callable_array" test.lkt:13:5-13:44>
+
+Expr <RefId "callable_array" test.lkt:17:30-17:44>
+     has type <FunctionType prelude: "() -> Array[MyCallable]">
+
+Expr <DotExpr test.lkt:17:25-17:44>
+     has type <FunctionType prelude: "() -> Array[MyCallable]">
+
+Expr <CallExpr test.lkt:17:25-17:46>
+     has type <InstantiatedGenericType prelude: "Array[MyCallable]">
+
+Expr <NumLit test.lkt:17:47-17:49>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:17:25-17:50>
+     has type <ClassDecl "MyCallable" test.lkt:1:1-3:2>
+
+Expr <NumLit test.lkt:17:51-17:53>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:17:25-17:54>
+     has type <EnumTypeDecl prelude: "Bool">
+
+Id   <RefId "RecursiveCallable" test.lkt:18:18-18:35>
+     references <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Id   <RefId "RecursiveCallable" test.lkt:18:38-18:55>
+     references <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <CallExpr test.lkt:18:38-18:57>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:58-18:60>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:61>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:62-18:64>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:65>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:66-18:68>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:69>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:70-18:72>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:73>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:74-18:76>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:77>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:78-18:80>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:81>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:82-18:84>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:85>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:86-18:88>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:89>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:90-18:92>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:93>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:94-18:96>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:97>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:98-18:100>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:101>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:102-18:104>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:105>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:106-18:108>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:109>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+
+Expr <NumLit test.lkt:18:110-18:112>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:18:38-18:113>
+     has type <ClassDecl "RecursiveCallable" test.lkt:5:1-7:2>
+

--- a/testsuite/tests/contrib/lkt_semantic/advanced_calls/test.yaml
+++ b/testsuite/tests/contrib/lkt_semantic/advanced_calls/test.yaml
@@ -1,0 +1,1 @@
+driver: lkt

--- a/testsuite/tests/contrib/lkt_semantic/array_list_methods/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/array_list_methods/test.out
@@ -88,6 +88,3 @@ test.lkt:13:66: error: Cannot find entity `self` in this scope
 12 | @invalid fun test_astlist_indexing(a: ASTList[String]): String = self(12)
    |                                                                  ^^^^    
 
-Expr <CallExpr test.lkt:13:66-13:74>
-     has type <StructDecl prelude: "String">
-

--- a/testsuite/tests/contrib/lkt_semantic/builtin_methods/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/builtin_methods/test.lkt
@@ -23,6 +23,6 @@ class Name : RootNode implements TokenNode {
     fun parent_nodes (): Array[RootNode] = node.parents()
     fun parent_nodes (): Array[RootNode] = node.parents(with_self=false)
 
-    fun node_iterator (): Iterator[RootNode] = node.parents().to_iterator
+    fun node_iterator (): Iterator[RootNode] = node.parents().to_iterator()
 
 }

--- a/testsuite/tests/contrib/lkt_semantic/builtin_methods/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/builtin_methods/test.out
@@ -460,8 +460,11 @@ Id   <RefId "to_iterator" test.lkt:26:63-26:74>
      references <FunDecl prelude: "to_iterator">
 
 Expr <RefId "to_iterator" test.lkt:26:63-26:74>
-     has type <InstantiatedGenericType prelude: "Iterator[RootNode]">
+     has type <FunctionType prelude: "() -> Iterator[RootNode]">
 
 Expr <DotExpr test.lkt:26:48-26:74>
+     has type <FunctionType prelude: "() -> Iterator[RootNode]">
+
+Expr <CallExpr test.lkt:26:48-26:76>
      has type <InstantiatedGenericType prelude: "Iterator[RootNode]">
 

--- a/testsuite/tests/contrib/lkt_semantic/call_non_callable/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/call_non_callable/test.lkt
@@ -1,0 +1,7 @@
+# Error for trying to call a non callable
+
+val a: (Int) -> Int = null
+@invalid val b: Int = a(12)()
+
+fun c(i: Int): Int = i + 2
+@invalid val d: Int = a(12)()

--- a/testsuite/tests/contrib/lkt_semantic/call_non_callable/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/call_non_callable/test.out
@@ -1,0 +1,73 @@
+Resolving test.lkt
+==================
+Id   <RefId "Int" test.lkt:3:9-3:12>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "Int" test.lkt:3:17-3:20>
+     references <StructDecl prelude: "Int">
+
+Expr <NullLit test.lkt:3:23-3:27>
+     has type <FunctionType prelude: "(Int) -> Int">
+
+Id   <RefId "Int" test.lkt:4:17-4:20>
+     references <StructDecl prelude: "Int">
+
+test.lkt:4:23: error: Object of type `Int` is not callable
+3 | @invalid val b: Int = a(12)()
+  |                       ^^^^^  
+
+Id   <RefId "a" test.lkt:4:23-4:24>
+     references <ValDecl "a" test.lkt:3:1-3:27>
+
+Expr <RefId "a" test.lkt:4:23-4:24>
+     has type <FunctionType prelude: "(Int) -> Int">
+
+Expr <NumLit test.lkt:4:25-4:27>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:4:23-4:28>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:4:23-4:30>
+     has type <StructDecl prelude: "Int">
+
+Id   <RefId "Int" test.lkt:6:10-6:13>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "Int" test.lkt:6:16-6:19>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "i" test.lkt:6:22-6:23>
+     references <FunArgDecl "i" test.lkt:6:7-6:13>
+
+Expr <RefId "i" test.lkt:6:22-6:23>
+     has type <StructDecl prelude: "Int">
+
+Expr <NumLit test.lkt:6:26-6:27>
+     has type <StructDecl prelude: "Int">
+
+Expr <BinOp test.lkt:6:22-6:27>
+     has type <StructDecl prelude: "Int">
+
+Id   <RefId "Int" test.lkt:7:17-7:20>
+     references <StructDecl prelude: "Int">
+
+test.lkt:7:23: error: Object of type `Int` is not callable
+6 | @invalid val d: Int = a(12)()
+  |                       ^^^^^  
+
+Id   <RefId "a" test.lkt:7:23-7:24>
+     references <ValDecl "a" test.lkt:3:1-3:27>
+
+Expr <RefId "a" test.lkt:7:23-7:24>
+     has type <FunctionType prelude: "(Int) -> Int">
+
+Expr <NumLit test.lkt:7:25-7:27>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:7:23-7:28>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:7:23-7:30>
+     has type <StructDecl prelude: "Int">
+

--- a/testsuite/tests/contrib/lkt_semantic/call_non_callable/test.yaml
+++ b/testsuite/tests/contrib/lkt_semantic/call_non_callable/test.yaml
@@ -1,0 +1,1 @@
+driver: lkt

--- a/testsuite/tests/contrib/lkt_semantic/call_non_static_decl/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/call_non_static_decl/test.lkt
@@ -1,0 +1,4 @@
+# Call a non static declaration
+
+val a: (Int) -> Int = null
+val b: Int = a(12)

--- a/testsuite/tests/contrib/lkt_semantic/call_non_static_decl/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/call_non_static_decl/test.out
@@ -1,0 +1,26 @@
+Resolving test.lkt
+==================
+Id   <RefId "Int" test.lkt:3:9-3:12>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "Int" test.lkt:3:17-3:20>
+     references <StructDecl prelude: "Int">
+
+Expr <NullLit test.lkt:3:23-3:27>
+     has type <FunctionType prelude: "(Int) -> Int">
+
+Id   <RefId "Int" test.lkt:4:8-4:11>
+     references <StructDecl prelude: "Int">
+
+Id   <RefId "a" test.lkt:4:14-4:15>
+     references <ValDecl "a" test.lkt:3:1-3:27>
+
+Expr <RefId "a" test.lkt:4:14-4:15>
+     has type <FunctionType prelude: "(Int) -> Int">
+
+Expr <NumLit test.lkt:4:16-4:18>
+     has type <StructDecl prelude: "Int">
+
+Expr <CallExpr test.lkt:4:14-4:19>
+     has type <StructDecl prelude: "Int">
+

--- a/testsuite/tests/contrib/lkt_semantic/call_non_static_decl/test.yaml
+++ b/testsuite/tests/contrib/lkt_semantic/call_non_static_decl/test.yaml
@@ -1,0 +1,1 @@
+driver: lkt

--- a/testsuite/tests/contrib/lkt_semantic/dot_call_invalid/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/dot_call_invalid/test.out
@@ -19,6 +19,3 @@ test.lkt:4:26: error: Cannot find entity `plus` in this scope
 3 | @invalid val b : Int = a.plus(2)
   |                          ^^^^   
 
-Expr <CallExpr test.lkt:4:24-4:33>
-     has type <StructDecl prelude: "Int">
-


### PR DESCRIPTION
This fixes several bugs in the call decl/type resolution mechanism

* Generally make `called_decl` only return a called decl when there is
  one for the specific callexpr. Before, for nested call expressions
  like `a()()()` it would return the sub call-expression called decl.

* Make `expr_context_free_type` compute the type even when there is no
  called declaration