### PR TITLE
U914-006: emit error message on dependency not found

### DIFF
--- a/contrib/lkt/language/parser.py
+++ b/contrib/lkt/language/parser.py
@@ -507,6 +507,14 @@ class Import(LKNode):
         """
         return Self.internal_fetch_referenced_unit(Self.name.text)
 
+    @langkit_property(return_type=T.SemanticResult.array)
+    def check_correctness_pre():
+        return If(
+            Self.referenced_unit.root.is_null,
+            Entity.error(S("cannot find ").concat(Self.name.text)).singleton,
+            No(T.SemanticResult.array)
+        )
+
     env_spec = EnvSpec(
         do(Self.referenced_unit)
     )

--- a/testsuite/tests/contrib/lkt_semantic/invalid_import/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_import/test.lkt
@@ -1,0 +1,1 @@
+import invalid_import

--- a/testsuite/tests/contrib/lkt_semantic/invalid_import/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_import/test.out
@@ -1,0 +1,6 @@
+Resolving test.lkt
+==================
+test.lkt:1:1: error: cannot find invalid_import
+0 | import invalid_import
+  | ^^^^^^^^^^^^^^^^^^^^^
+

--- a/testsuite/tests/contrib/lkt_semantic/invalid_import/test.yaml
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_import/test.yaml
@@ -1,0 +1,1 @@
+driver: lkt


### PR DESCRIPTION
Properly emit an error message when the file pointed out by an
`import` statement is not found.