### PR TITLE
U918-003: Allow list of `env_assocs` in `add_to_env_by_name`.

### DIFF
--- a/langkit/envs.py
+++ b/langkit/envs.py
@@ -157,10 +157,37 @@ def add_to_env_kv(key: AbstractExpression,
     )
 
 
-def add_to_env_by_name(key: AbstractExpression,
-                       val: AbstractExpression,
+def add_to_env_by_name(mappings: AbstractExpression,
                        name: AbstractExpression,
                        fallback_env: AbstractExpression) -> AddToEnv:
+    """Add several entries to a potentially foreign lexical env.
+
+    The target lexical environment is:
+
+    * If ``name`` returns a non-null env name, the environment that has this
+      name (according to precedence rules).
+
+    * Otherwise, the environment that the ``fallback_env`` expression returns.
+      In that case, the environment cannot be foreign.
+
+    :param mappings: One or several mappings of key to value to add to the
+        environment. Must be either of type T.env_assoc, or T.env_assoc.array.
+        All values must belong to the same unit as the node that owns this
+        EnvSpec. See langkit.expressions.envs.new_env_assoc for more precision
+        on how to create an env assoc.
+    """
+    return AddToEnv(
+        mappings=mappings,
+        resolver=None,
+        name_expr=name,
+        fallback_env_expr=fallback_env,
+    )
+
+
+def add_to_env_by_name_kv(key: AbstractExpression,
+                          val: AbstractExpression,
+                          name: AbstractExpression,
+                          fallback_env: AbstractExpression) -> AddToEnv:
     """Add an entry to a potentially foreign lexical env.
 
     The target lexical environment is:

--- a/testsuite/tests/lexical_envs/named_envs/test.py
+++ b/testsuite/tests/lexical_envs/named_envs/test.py
@@ -22,7 +22,7 @@ units loading.
 
 from langkit.dsl import ASTNode, Field, T, abstract
 from langkit.envs import (
-    EnvSpec, RefKind, add_env, add_to_env_by_name, add_to_env_kv, reference,
+    EnvSpec, RefKind, add_env, add_to_env_by_name_kv, add_to_env_kv, reference,
     set_initial_env_by_name,
 )
 from langkit.expressions import (AbstractKind, If, Let, No, Not, Self, String,
@@ -348,7 +348,7 @@ class PackageBody(FooNode):
             Self.parent.children_env,
         ),
 
-        add_to_env_by_name(
+        add_to_env_by_name_kv(
             '__nextpart',
             Self,
             If(Self.can_have_name,


### PR DESCRIPTION
This change renames the current implementation of `add_to_env_by_name` (which
takes a single key value pair) to `add_to_env_by_name_kv`, in order to match
the naming scheme used for `add_to_env` / `add_to_env_kv`.

The current `add_to_env_by_name` is repurposed to take a list of env assocs
instead, as is done by `add_to_env`.

Having an `add_to_env_by_name` which takes a list of `env_assoc`s is needed to
implement the fix for this ticket on the LAL side.