### PR TITLE
Lkt: add unique builtin to Array type in prelude.lkt

### DIFF
--- a/contrib/lkt/language/prelude.lkt
+++ b/contrib/lkt/language/prelude.lkt
@@ -36,6 +36,7 @@ trait Iterator {
 @builtin generic[T]
 struct Array implements Sized, Indexable[T], Iterator[T] {
     @builtin fun to_iterator(): Iterator[T]
+    @builtin fun unique(): Array[T]
 }
 
 @builtin generic[T]

--- a/testsuite/tests/properties/unique/test.py
+++ b/testsuite/tests/properties/unique/test.py
@@ -20,5 +20,6 @@ class Example(FooNode):
         return a.unique
 
 
-build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py')
+build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py',
+              lkt_semantic_checks=True)
 print('Done')


### PR DESCRIPTION
Enable lkt_semantic_checks on properties/unique test by adding the
``unique`` buitin for the Array type in lkt's prelude.