### PR TITLE
Lkt: add as_bare_entity property in prelude's Node declaration

### DIFF
--- a/contrib/lkt/language/prelude.lkt
+++ b/contrib/lkt/language/prelude.lkt
@@ -72,6 +72,7 @@ struct ASTList implements Sized, Indexable[T], Iterator[T] {
 }
 
 @builtin generic[RootNode] trait Node {
+    @builtin @property fun as_bare_entity(): RootNode
     @builtin @property fun parent(): RootNode
     @builtin fun node_env(): LexicalEnv[RootNode]
     @builtin fun children_env(): LexicalEnv[RootNode]

--- a/testsuite/tests/properties/analysis_unit_from_node/test.py
+++ b/testsuite/tests/properties/analysis_unit_from_node/test.py
@@ -28,5 +28,6 @@ class Plus(Expression):
     right = Field()
 
 
-build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py')
+build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py',
+              lkt_semantic_checks=True)
 print('Done')

--- a/testsuite/tests/properties/memoized_unit/test.py
+++ b/testsuite/tests/properties/memoized_unit/test.py
@@ -15,5 +15,6 @@ class Example(FooNode):
         return unit.root.as_bare_entity
 
 
-build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py')
+build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py',
+              lkt_semantic_checks=True)
 print('Done')

--- a/testsuite/tests/properties/parents/test.py
+++ b/testsuite/tests/properties/parents/test.py
@@ -32,5 +32,6 @@ class Example(FooNode):
     token_node = True
 
 
-build_and_run(lkt_file="expected_concrete_syntax.lkt", py_script="main.py")
+build_and_run(lkt_file="expected_concrete_syntax.lkt", py_script="main.py",
+              lkt_semantic_checks=True)
 print("Done")


### PR DESCRIPTION
This patch allows to enable semantic checks on the following tests:
properties/analysis_unit_from_node, properties/memoized_unit, and
properties/parents.