### PR TITLE
U920-003: enable more semantic checks

### DIFF
--- a/testsuite/tests/properties/equality/test.py
+++ b/testsuite/tests/properties/equality/test.py
@@ -63,6 +63,6 @@ class Ref(FooNode):
 
 build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py',
 
-              # FIXME: switch back to True, see U920-003
+              # FIXME: switch back to True, see U930-033
               lkt_semantic_checks=False)
 print('Done')

--- a/testsuite/tests/properties/lower_dispatch_rewrite/test.py
+++ b/testsuite/tests/properties/lower_dispatch_rewrite/test.py
@@ -95,5 +95,6 @@ class Def(FooNode):
     )
 
 
-build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py')
+build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py',
+              lkt_semantic_checks=True)
 print('Done')


### PR DESCRIPTION
The error reported in this TN doesn't exist anymore, so just turn on the semantic checks here.