### PR TITLE
Lkt: check for @invalid annotations in lkt_toolbox

### DIFF
--- a/contrib/lkt/extensions/mains/lkt_toolbox.adb
+++ b/contrib/lkt/extensions/mains/lkt_toolbox.adb
@@ -1,3 +1,5 @@
+with Ada.Command_Line;            use Ada.Command_Line;
+with Ada.Containers.Hashed_Maps;
 with Ada.Directories;             use Ada.Directories;
 with Ada.Exceptions;
 with Ada.Strings.Fixed;           use Ada.Strings.Fixed;
@@ -13,6 +15,7 @@ with Langkit_Support.Diagnostics; use Langkit_Support.Diagnostics;
 with Langkit_Support.Diagnostics.Output;
 use Langkit_Support.Diagnostics.Output;
 
+with Langkit_Support.Slocs;       use Langkit_Support.Slocs;
 with Langkit_Support.Text;        use Langkit_Support.Text;
 
 with Liblktlang.Analysis;         use Liblktlang.Analysis;
@@ -42,12 +45,36 @@ procedure Lkt_Toolbox is
 
    use Liblktlang;
 
+   package Invalid_Decl_Maps is new Ada.Containers.Hashed_Maps
+     (Key_Type        => Analysis.LK_Node,
+      Element_Type    => Boolean,
+      Hash            => Analysis.Hash,
+      Equivalent_Keys => "=");
+
    procedure Print_Semantic_Result
      (S : Analysis.Semantic_Result; Unit : Analysis.Analysis_Unit);
    --  Print a semantic result
 
    function Format_Node (Decl_Node : Decl'Class) return String;
    --  Format node for semantic result printing
+
+   procedure Print_Lkt_Toolbox_Diagnostic
+     (Node : LK_Node'Class; Message : Wide_Wide_String);
+   --  Internal wrapper to ``Print_Diagnostic`` used by lkt_toolbox to print
+   --  additional diagnostics.
+
+   function Populate_Invalid_Decl_Map
+     (Node : Analysis.LK_Node'Class) return Common.Visit_Status;
+   --  Populate ``Invalid_Decl_Map`` and reject declarations with ``@invalid``
+   --  annotations that are nested in another declaration annotated with
+   --  ``@invalid``.
+
+   Invalid_Decl_Map : Invalid_Decl_Maps.Map;
+   --  Map of declarations annotated with ``@invalid``. The boolean elements of
+   --  the map are initialized to ``False`` and set to ``True`` whenever a
+   --  diagnostic is emitted for the related declaration. Therefore, this map
+   --  is used to check that at least one diagnostic has been emitted for each
+   --  declaration annotated with ``@invalid``.
 
    -----------------
    -- Format_Node --
@@ -60,6 +87,20 @@ procedure Lkt_Toolbox is
       return Decl_Node.P_As_Bare_Decl.Image;
    end Format_Node;
 
+   ----------------------------------
+   -- Print_Lkt_Toolbox_Diagnostic --
+   ----------------------------------
+
+   procedure Print_Lkt_Toolbox_Diagnostic
+     (Node : LK_Node'Class; Message : Wide_Wide_String)
+   is
+      Sloc_Range : constant Source_Location_Range := Node.Sloc_Range;
+      Unit       : constant Analysis.Analysis_Unit := Node.Unit;
+      Path       : constant String := Simple_Name (Unit.Get_Filename);
+   begin
+      Print_Diagnostic ((Sloc_Range, To_Unbounded_Text (Message)), Unit, Path);
+   end Print_Lkt_Toolbox_Diagnostic;
+
    ---------------------------
    -- Print_Semantic_Result --
    ---------------------------
@@ -67,33 +108,77 @@ procedure Lkt_Toolbox is
    procedure Print_Semantic_Result
      (S : Analysis.Semantic_Result; Unit : Analysis.Analysis_Unit)
    is
+      Node : constant LK_Node'Class := Analysis.Node (S);
    begin
       if Analysis.Error_Message (S) /= "" then
          declare
             Diag : constant Diagnostic :=
-              (Analysis.Node (S).Sloc_Range,
+              (Node.Sloc_Range,
                To_Unbounded_Text (Analysis.Error_Message (S)));
          begin
+            --  Emit an error if the declaration including ``Node`` has no
+            --  ``@invalid`` annotation. Update ``Invalid_Decl_Map`` otherwise.
+
+            if Node.P_Topmost_Invalid_Decl.Is_Null then
+               Set_Exit_Status (1);
+
+               Print_Lkt_Toolbox_Diagnostic
+                 (Node,
+                  "unexpected diagnostic, is @invalid annotation missing?");
+            else
+               Invalid_Decl_Map (Node.P_Topmost_Invalid_Decl) := True;
+            end if;
+
             Print_Diagnostic
-              (Diag, Unit,
-               Simple_Name (Analysis.Node (S).Unit.Get_Filename));
+              (Diag, Unit, Simple_Name (Node.Unit.Get_Filename));
          end;
       elsif
         not Arg.Check_Only.Get
         and then not Analysis.Result_Type (S).Is_Null
       then
-         Put_Line ("Expr " & Analysis.Node (S).Image);
+         Put_Line ("Expr " & Node.Image);
          Put_Line ("     has type " & Analysis.Result_Type (S).Image);
          New_Line;
       elsif
       not Arg.Check_Only.Get
         and then not Analysis.Result_Ref (S).Is_Null
       then
-         Put_Line ("Id   " & Analysis.Node (S).Image);
+         Put_Line ("Id   " & Node.Image);
          Put_Line ("     references " & Format_Node (Analysis.Result_Ref (S)));
          New_Line;
       end if;
    end Print_Semantic_Result;
+
+   -------------------------------
+   -- Populate_Invalid_Decl_Map --
+   -------------------------------
+
+   function Populate_Invalid_Decl_Map
+     (Node : Analysis.LK_Node'Class) return Common.Visit_Status
+   is
+      use type Common.LK_Node_Kind_Type;
+   begin
+      --  Populate ``Invalid_Decl_Map`` with declarations annotated with
+      --  ``@invalid``.
+
+      if Node.Kind = Common.Lkt_Full_Decl
+         and then Node.As_Full_Decl.P_Has_Annotation
+           (To_Unbounded_Text ("invalid"))
+      then
+         --  ``P_Topmost_Invalid_Decl`` should return the same node. In that
+         --  case, include this node in the map, otherwise nested ``@invalid``
+         --  declarations have been detected: emit a diagnostic.
+
+         if Invalid_Decl_Map.Contains (Node.P_Topmost_Invalid_Decl) then
+            Set_Exit_Status (1);
+
+            Print_Lkt_Toolbox_Diagnostic (Node, "nested @invalid declaration");
+         else
+            Invalid_Decl_Map.Include (Node.As_LK_Node, False);
+         end if;
+      end if;
+      return Common.Into;
+   end Populate_Invalid_Decl_Map;
 
    Ctx : constant Analysis.Analysis_Context := Analysis.Create_Context;
 begin
@@ -119,6 +204,8 @@ begin
                return;
             end if;
 
+            Unit.Root.Traverse (Populate_Invalid_Decl_Map'Access);
+
             declare
                Diags : constant Analysis.Tree_Semantic_Result :=
                  Unit.Root.P_Check_Semantic;
@@ -127,6 +214,20 @@ begin
                   Print_Semantic_Result (D, Unit);
                end loop;
             end;
+
+            --  Ensure that all ``@invalid`` declarations in the map have been
+            --  reported. Print a diagnostic otherwise.
+
+            for E in Invalid_Decl_Map.Iterate loop
+               if not Invalid_Decl_Maps.Element (E) then
+                  Set_Exit_Status (1);
+
+                  Print_Lkt_Toolbox_Diagnostic
+                    (Invalid_Decl_Maps.Key (E),
+                     "@invalid declaration without diagnostic");
+               end if;
+            end loop;
+
          end;
       end loop;
    end if;

--- a/contrib/lkt/language/parser.py
+++ b/contrib/lkt/language/parser.py
@@ -470,6 +470,17 @@ class LKNode(ASTNode):
             Entity.parent
         )
 
+    @langkit_property(public=True)
+    def topmost_invalid_decl():
+        """
+        Return the topmost (from ``Self`` to the root node) FullDecl annotated
+        with ``@invalid``, null otherwise.
+        """
+        return Self.parents().filter(
+            lambda p:
+            p.cast(FullDecl).then(lambda fd: fd.has_annotation("invalid"))
+        ).at(-1)
+
 
 class LangkitRoot(LKNode):
     """
@@ -563,7 +574,7 @@ class FullDecl(LKNode):
     decl_annotations = Field(type=T.DeclAnnotation.list)
     decl = Field(type=T.Decl)
 
-    @langkit_property()
+    @langkit_property(public=True)
     def has_annotation(name=T.Symbol):
         """
         Return whether this node has an annotation with name ``name``.

--- a/testsuite/tests/contrib/lkt_semantic/ambiguous_type/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/ambiguous_type/test.lkt
@@ -1,4 +1,4 @@
 # Test that an error message is emitted in the case of an ambiguously typed
 # expression.
 
-val a = "hello"
+@invalid val a = "hello"

--- a/testsuite/tests/contrib/lkt_semantic/ambiguous_type/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/ambiguous_type/test.out
@@ -1,6 +1,6 @@
 Resolving test.lkt
 ==================
-test.lkt:4:9: error: ambiguous type for expression
-4 | val a = "hello"
-  |         ^^^^^^^
+test.lkt:4:18: error: ambiguous type for expression
+4 | @invalid val a = "hello"
+  |                  ^^^^^^^
 

--- a/testsuite/tests/contrib/lkt_semantic/base_test/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/base_test/test.lkt
@@ -3,15 +3,15 @@
 
     fun test_int(): Int = 12
 
-    fun test_int_invalid(): A = 12
+    @invalid fun test_int_invalid(): A = 12
 
     fun test_int_add(): Int = 12 + 15
 
-    fun test_int_add_invalid_1(): Int = "12" + 15
+    @invalid fun test_int_add_invalid_1(): Int = "12" + 15
 
-    fun test_int_add_invalid_2(): Int = 15 + self
+    @invalid fun test_int_add_invalid_2(): Int = 15 + self
 
-    fun test_int_add_invalid_3(): A = 15 + self
+    @invalid fun test_int_add_invalid_3(): A = 15 + self
 
     fun test_regexp_1(): Regexp = p"[a-z]"
 
@@ -22,7 +22,7 @@
 
     fun test_if_1(): Int = if true then 1 else 2
 
-    fun test_if_invalid_1(): Int = if true then 1 else "2"
+    @invalid fun test_if_invalid_1(): Int = if true then 1 else "2"
 }
 
 generic [C]
@@ -42,9 +42,9 @@ struct Tuple2 {
 class B : A {
     fun test_generic_constructor(): Pair[Int] = Pair[Int](12, 15)
     fun test_generic_component_access(): Int = Pair[Int](12,  15).a
-    fun test_invalid_generic_type(): Pair[Int] = Pair[Int](12, 15).a
+    @invalid fun test_invalid_generic_type(): Pair[Int] = Pair[Int](12, 15).a
     fun test_generic_component_access_2(): Bool = Tuple2[Int, Bool](12, true).b
-    fun test_invalid_generic_type_2(): Tuple2[Int, Bool] = true
+    @invalid fun test_invalid_generic_type_2(): Tuple2[Int, Bool] = true
     fun test_fun_call(arg: A): Int = arg.test_int_add()
     fun test_struct_fun(arg: Tuple2[Int, Bool]): Int = arg.test()
     fun test_array_indexing(arg: Array[Int]): Int = arg(12)
@@ -54,7 +54,7 @@ val a: Int = 12
 
 struct Foo {
     # Test that you cannot access toplevel declarations from a nested scope.
-    fun test_identifier_leak_invalid(): Int = self.a
+    @invalid fun test_identifier_leak_invalid(): Int = self.a
 }
 
 enum class C {

--- a/testsuite/tests/contrib/lkt_semantic/base_test/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/base_test/test.out
@@ -15,12 +15,12 @@ Id   <RefId "Int" test.lkt:4:21-4:24>
 Expr <NumLit test.lkt:4:27-4:29>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "A" test.lkt:6:29-6:30>
+Id   <RefId "A" test.lkt:6:38-6:39>
      references <ClassDecl "A" test.lkt:1:12-26:2>
 
-test.lkt:6:33: error: Mismatched types: expected `A`, got a number literal
-6 |     fun test_int_invalid(): A = 12
-  |                                 ^^
+test.lkt:6:42: error: Mismatched types: expected `A`, got a number literal
+6 |     @invalid fun test_int_invalid(): A = 12
+  |                                          ^^
 
 Id   <RefId "Int" test.lkt:8:25-8:28>
      references <StructDecl prelude: "Int">
@@ -34,49 +34,49 @@ Expr <NumLit test.lkt:8:36-8:38>
 Expr <BinOp test.lkt:8:31-8:38>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:10:35-10:38>
+Id   <RefId "Int" test.lkt:10:44-10:47>
      references <StructDecl prelude: "Int">
 
-test.lkt:10:41: error: Mismatched types: expected `Int`, got a string literal
-10 |     fun test_int_add_invalid_1(): Int = "12" + 15
-   |                                         ^^^^
+test.lkt:10:50: error: Mismatched types: expected `Int`, got a string literal
+10 |     @invalid fun test_int_add_invalid_1(): Int = "12" + 15
+   |                                                  ^^^^
 
-Expr <NumLit test.lkt:10:48-10:50>
+Expr <NumLit test.lkt:10:57-10:59>
      has type <StructDecl prelude: "Int">
 
-Expr <BinOp test.lkt:10:41-10:50>
+Expr <BinOp test.lkt:10:50-10:59>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:12:35-12:38>
+Id   <RefId "Int" test.lkt:12:44-12:47>
      references <StructDecl prelude: "Int">
 
-Expr <NumLit test.lkt:12:41-12:43>
+Expr <NumLit test.lkt:12:50-12:52>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "self" test.lkt:12:46-12:50>
+Id   <RefId "self" test.lkt:12:55-12:59>
      references <SelfDecl "self" test.lkt:1:12-26:2>
 
-test.lkt:12:46: error: Mismatched types: expected `Int`, got `A`
-12 |     fun test_int_add_invalid_2(): Int = 15 + self
-   |                                              ^^^^
+test.lkt:12:55: error: Mismatched types: expected `Int`, got `A`
+12 |     @invalid fun test_int_add_invalid_2(): Int = 15 + self
+   |                                                       ^^^^
 
-Expr <BinOp test.lkt:12:41-12:50>
+Expr <BinOp test.lkt:12:50-12:59>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "A" test.lkt:14:35-14:36>
+Id   <RefId "A" test.lkt:14:44-14:45>
      references <ClassDecl "A" test.lkt:1:12-26:2>
 
-test.lkt:14:39: error: Mismatched types: expected `A`, got a number literal
-14 |     fun test_int_add_invalid_3(): A = 15 + self
-   |                                       ^^
+test.lkt:14:48: error: Mismatched types: expected `A`, got a number literal
+14 |     @invalid fun test_int_add_invalid_3(): A = 15 + self
+   |                                                ^^
 
-Id   <RefId "self" test.lkt:14:44-14:48>
+Id   <RefId "self" test.lkt:14:53-14:57>
      references <SelfDecl "self" test.lkt:1:12-26:2>
 
-Expr <RefId "self" test.lkt:14:44-14:48>
+Expr <RefId "self" test.lkt:14:53-14:57>
      has type <ClassDecl "A" test.lkt:1:12-26:2>
 
-Expr <BinOp test.lkt:14:39-14:48>
+Expr <BinOp test.lkt:14:48-14:57>
      has type <ClassDecl "A" test.lkt:1:12-26:2>
 
 Id   <RefId "Regexp" test.lkt:16:26-16:32>
@@ -118,23 +118,23 @@ Expr <NumLit test.lkt:23:48-23:49>
 Expr <IfExpr test.lkt:23:28-23:49>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:25:30-25:33>
+Id   <RefId "Int" test.lkt:25:39-25:42>
      references <StructDecl prelude: "Int">
 
-Id   <RefId "true" test.lkt:25:39-25:43>
+Id   <RefId "true" test.lkt:25:48-25:52>
      references <EnumLitDecl prelude: "true">
 
-Expr <RefId "true" test.lkt:25:39-25:43>
+Expr <RefId "true" test.lkt:25:48-25:52>
      has type <EnumTypeDecl prelude: "Bool">
 
-Expr <NumLit test.lkt:25:49-25:50>
+Expr <NumLit test.lkt:25:58-25:59>
      has type <StructDecl prelude: "Int">
 
-test.lkt:25:56: error: Mismatched types: expected `Int`, got a string literal
-25 |     fun test_if_invalid_1(): Int = if true then 1 else "2"
-   |                                                        ^^^
+test.lkt:25:65: error: Mismatched types: expected `Int`, got a string literal
+25 |     @invalid fun test_if_invalid_1(): Int = if true then 1 else "2"
+   |                                                                 ^^^
 
-Expr <IfExpr test.lkt:25:36-25:59>
+Expr <IfExpr test.lkt:25:45-25:68>
      has type <StructDecl prelude: "Int">
 
 Id   <RefId "C" test.lkt:30:8-30:9>
@@ -203,36 +203,36 @@ Expr <RefId "a" test.lkt:44:67-44:68>
 Expr <DotExpr test.lkt:44:48-44:68>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Pair" test.lkt:45:38-45:42>
+Id   <RefId "Pair" test.lkt:45:47-45:51>
      references <GenericDecl "Pair" test.lkt:28:1-32:2>
 
-Id   <RefId "Int" test.lkt:45:43-45:46>
+Id   <RefId "Int" test.lkt:45:52-45:55>
      references <StructDecl prelude: "Int">
 
-Id   <RefId "Pair" test.lkt:45:50-45:54>
+Id   <RefId "Pair" test.lkt:45:59-45:63>
      references <GenericDecl "Pair" test.lkt:28:1-32:2>
 
-Id   <RefId "Int" test.lkt:45:55-45:58>
+Id   <RefId "Int" test.lkt:45:64-45:67>
      references <StructDecl prelude: "Int">
 
-Expr <NumLit test.lkt:45:60-45:62>
+Expr <NumLit test.lkt:45:69-45:71>
      has type <StructDecl prelude: "Int">
 
-Expr <NumLit test.lkt:45:64-45:66>
+Expr <NumLit test.lkt:45:73-45:75>
      has type <StructDecl prelude: "Int">
 
-Expr <CallExpr test.lkt:45:50-45:67>
+Expr <CallExpr test.lkt:45:59-45:76>
      has type <InstantiatedGenericType "Pair[Int]" test.lkt:28:1-32:2>
 
-Id   <RefId "a" test.lkt:45:68-45:69>
+Id   <RefId "a" test.lkt:45:77-45:78>
      references <FieldDecl "a" test.lkt:30:5-30:9>
 
-Expr <RefId "a" test.lkt:45:68-45:69>
+Expr <RefId "a" test.lkt:45:77-45:78>
      has type <StructDecl prelude: "Int">
 
-test.lkt:45:50: error: Mismatched types: expected `Pair[Int]`, got `Int`
-45 |     fun test_invalid_generic_type(): Pair[Int] = Pair[Int](12, 15).a
-   |                                                  ^^^^^^^^^^^^^^^^^^^
+test.lkt:45:59: error: Mismatched types: expected `Pair[Int]`, got `Int`
+45 |     @invalid fun test_invalid_generic_type(): Pair[Int] = Pair[Int](12, 15).a
+   |                                                           ^^^^^^^^^^^^^^^^^^^
 
 Id   <RefId "Bool" test.lkt:46:44-46:48>
      references <EnumTypeDecl prelude: "Bool">
@@ -267,21 +267,21 @@ Expr <RefId "b" test.lkt:46:79-46:80>
 Expr <DotExpr test.lkt:46:51-46:80>
      has type <EnumTypeDecl prelude: "Bool">
 
-Id   <RefId "Tuple2" test.lkt:47:40-47:46>
+Id   <RefId "Tuple2" test.lkt:47:49-47:55>
      references <GenericDecl "Tuple2" test.lkt:34:1-40:2>
 
-Id   <RefId "Int" test.lkt:47:47-47:50>
+Id   <RefId "Int" test.lkt:47:56-47:59>
      references <StructDecl prelude: "Int">
 
-Id   <RefId "Bool" test.lkt:47:52-47:56>
+Id   <RefId "Bool" test.lkt:47:61-47:65>
      references <EnumTypeDecl prelude: "Bool">
 
-Id   <RefId "true" test.lkt:47:60-47:64>
+Id   <RefId "true" test.lkt:47:69-47:73>
      references <EnumLitDecl prelude: "true">
 
-test.lkt:47:60: error: Mismatched types: expected `Tuple2[Int, Bool]`, got `Bool`
-47 |     fun test_invalid_generic_type_2(): Tuple2[Int, Bool] = true
-   |                                                            ^^^^
+test.lkt:47:69: error: Mismatched types: expected `Tuple2[Int, Bool]`, got `Bool`
+47 |     @invalid fun test_invalid_generic_type_2(): Tuple2[Int, Bool] = true
+   |                                                                     ^^^^
 
 Id   <RefId "A" test.lkt:48:28-48:29>
      references <ClassDecl "A" test.lkt:1:12-26:2>
@@ -364,18 +364,18 @@ Id   <RefId "Int" test.lkt:53:8-53:11>
 Expr <NumLit test.lkt:53:14-53:16>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:57:41-57:44>
+Id   <RefId "Int" test.lkt:57:50-57:53>
      references <StructDecl prelude: "Int">
 
-Id   <RefId "self" test.lkt:57:47-57:51>
+Id   <RefId "self" test.lkt:57:56-57:60>
      references <SelfDecl "self" test.lkt:55:1-58:2>
 
-Expr <RefId "self" test.lkt:57:47-57:51>
+Expr <RefId "self" test.lkt:57:56-57:60>
      has type <StructDecl "Foo" test.lkt:55:1-58:2>
 
-test.lkt:57:52: error: Cannot find entity `a` in this scope
-57 |     fun test_identifier_leak_invalid(): Int = self.a
-   |                                                    ^
+test.lkt:57:61: error: Cannot find entity `a` in this scope
+57 |     @invalid fun test_identifier_leak_invalid(): Int = self.a
+   |                                                             ^
 
 Id   <RefId "D" test.lkt:62:16-62:17>
      references <EnumClassAltDecl "D" test.lkt:61:10-61:11>

--- a/testsuite/tests/contrib/lkt_semantic/erroneous_component_access/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/erroneous_component_access/test.lkt
@@ -1,3 +1,3 @@
-fun test(a: Int): Cls
+@invalid fun test(a: Int): Cls
 
 val a: Int = test(12).a

--- a/testsuite/tests/contrib/lkt_semantic/erroneous_component_access/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/erroneous_component_access/test.out
@@ -1,17 +1,17 @@
 Resolving test.lkt
 ==================
-Id   <RefId "Int" test.lkt:1:13-1:16>
+Id   <RefId "Int" test.lkt:1:22-1:25>
      references <StructDecl prelude: "Int">
 
-test.lkt:1:19: error: Cannot find entity `Cls` in this scope
-1 | fun test(a: Int): Cls
-  |                   ^^^
+test.lkt:1:28: error: Cannot find entity `Cls` in this scope
+1 | @invalid fun test(a: Int): Cls
+  |                            ^^^
 
 Id   <RefId "Int" test.lkt:3:8-3:11>
      references <StructDecl prelude: "Int">
 
 Id   <RefId "test" test.lkt:3:14-3:18>
-     references <FunDecl "test" test.lkt:1:1-1:22>
+     references <FunDecl "test" test.lkt:1:10-1:31>
 
 Expr <NumLit test.lkt:3:19-3:21>
      has type <StructDecl prelude: "Int">

--- a/testsuite/tests/contrib/lkt_semantic/invalid_import/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_import/test.lkt
@@ -1,1 +1,1 @@
-import invalid_import
+@invalid import invalid_import

--- a/testsuite/tests/contrib/lkt_semantic/invalid_import/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_import/test.out
@@ -1,6 +1,6 @@
 Resolving test.lkt
 ==================
-test.lkt:1:1: error: cannot find invalid_import
-1 | import invalid_import
-  | ^^^^^^^^^^^^^^^^^^^^^
+test.lkt:1:10: error: Expected 'val', got 'import'
+1 | @invalid import invalid_import
+  |          ^^^^^^
 

--- a/testsuite/tests/contrib/lkt_semantic/invalid_type_ref/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_type_ref/test.lkt
@@ -2,7 +2,7 @@ generic [T]
 class U {
 }
 
-a: U
+@invalid a: U
 
-class V: U {
+@invalid class V: U {
 }

--- a/testsuite/tests/contrib/lkt_semantic/invalid_type_ref/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/invalid_type_ref/test.out
@@ -1,16 +1,16 @@
 Resolving test.lkt
 ==================
-test.lkt:5:4: error: Invalid type reference
-5 | a: U
-  |    ^
+test.lkt:5:13: error: Invalid type reference
+5 | @invalid a: U
+  |             ^
 
-Id   <RefId "U" test.lkt:5:4-5:5>
+Id   <RefId "U" test.lkt:5:13-5:14>
      references <GenericDecl "U" test.lkt:1:1-3:2>
 
-test.lkt:7:10: error: Invalid type reference
-7 | class V: U {
-  |          ^
+test.lkt:7:19: error: Invalid type reference
+7 | @invalid class V: U {
+  |                   ^
 
-Id   <RefId "U" test.lkt:7:10-7:11>
+Id   <RefId "U" test.lkt:7:19-7:20>
      references <GenericDecl "U" test.lkt:1:1-3:2>
 

--- a/testsuite/tests/contrib/lkt_semantic/object_call/test.lkt
+++ b/testsuite/tests/contrib/lkt_semantic/object_call/test.lkt
@@ -4,11 +4,11 @@
 fun arr(size: Int): Array[Int]
 val a: Int = arr(12)(1)
 
-@incorrect val incorrect_call: Int = arr(12)("a")
-@incorrect val incorrect_call_1: Int = arr(12)()
-@incorrect val incorrect_call_2: Int = arr(12)(1, 2)
+@invalid val incorrect_call: Int = arr(12)("a")
+@invalid val incorrect_call_1: Int = arr(12)()
+@invalid val incorrect_call_2: Int = arr(12)(1, 2)
 
 fun return_func(): (Int, Int) -> Int
 
 val a: Int = return_func()(1, 2)
-@incorrect val b: Int = return_func()(1, '2')
+@invalid val b: Int = return_func()(1, '2')

--- a/testsuite/tests/contrib/lkt_semantic/object_call/test.out
+++ b/testsuite/tests/contrib/lkt_semantic/object_call/test.out
@@ -30,77 +30,77 @@ Expr <NumLit test.lkt:5:22-5:23>
 Expr <CallExpr test.lkt:5:14-5:24>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:7:32-7:35>
+Id   <RefId "Int" test.lkt:7:30-7:33>
      references <StructDecl prelude: "Int">
 
-Id   <RefId "arr" test.lkt:7:38-7:41>
+Id   <RefId "arr" test.lkt:7:36-7:39>
      references <FunDecl "arr" test.lkt:4:1-4:31>
 
-Expr <RefId "arr" test.lkt:7:38-7:41>
+Expr <RefId "arr" test.lkt:7:36-7:39>
      has type <FunctionType prelude: "(Int) -> Array[Int]">
 
-Expr <NumLit test.lkt:7:42-7:44>
+Expr <NumLit test.lkt:7:40-7:42>
      has type <StructDecl prelude: "Int">
 
-Expr <CallExpr test.lkt:7:38-7:45>
+Expr <CallExpr test.lkt:7:36-7:43>
      has type <InstantiatedGenericType prelude: "Array[Int]">
 
-test.lkt:7:46: error: Mismatched types: expected `Int`, got a string literal
-7 | @incorrect val incorrect_call: Int = arr(12)("a")
-  |                                              ^^^
+test.lkt:7:44: error: Mismatched types: expected `Int`, got a string literal
+7 | @invalid val incorrect_call: Int = arr(12)("a")
+  |                                            ^^^
 
-Expr <CallExpr test.lkt:7:38-7:50>
+Expr <CallExpr test.lkt:7:36-7:48>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:8:34-8:37>
+Id   <RefId "Int" test.lkt:8:32-8:35>
      references <StructDecl prelude: "Int">
 
-test.lkt:8:40: error: No value for parameter
-8 | @incorrect val incorrect_call_1: Int = arr(12)()
-  |                                        ^^^^^^^^^
+test.lkt:8:38: error: No value for parameter
+8 | @invalid val incorrect_call_1: Int = arr(12)()
+  |                                      ^^^^^^^^^
 
-Id   <RefId "arr" test.lkt:8:40-8:43>
+Id   <RefId "arr" test.lkt:8:38-8:41>
      references <FunDecl "arr" test.lkt:4:1-4:31>
 
-Expr <RefId "arr" test.lkt:8:40-8:43>
+Expr <RefId "arr" test.lkt:8:38-8:41>
      has type <FunctionType prelude: "(Int) -> Array[Int]">
 
-Expr <NumLit test.lkt:8:44-8:46>
+Expr <NumLit test.lkt:8:42-8:44>
      has type <StructDecl prelude: "Int">
 
-Expr <CallExpr test.lkt:8:40-8:47>
+Expr <CallExpr test.lkt:8:38-8:45>
      has type <InstantiatedGenericType prelude: "Array[Int]">
 
-Expr <CallExpr test.lkt:8:40-8:49>
+Expr <CallExpr test.lkt:8:38-8:47>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:9:34-9:37>
+Id   <RefId "Int" test.lkt:9:32-9:35>
      references <StructDecl prelude: "Int">
 
-test.lkt:9:51: error: Unmatched actual
-9 | @incorrect val incorrect_call_2: Int = arr(12)(1, 2)
-  |                                                   ^
+test.lkt:9:49: error: Unmatched actual
+9 | @invalid val incorrect_call_2: Int = arr(12)(1, 2)
+  |                                                 ^
 
-Id   <RefId "arr" test.lkt:9:40-9:43>
+Id   <RefId "arr" test.lkt:9:38-9:41>
      references <FunDecl "arr" test.lkt:4:1-4:31>
 
-Expr <RefId "arr" test.lkt:9:40-9:43>
+Expr <RefId "arr" test.lkt:9:38-9:41>
      has type <FunctionType prelude: "(Int) -> Array[Int]">
 
-Expr <NumLit test.lkt:9:44-9:46>
+Expr <NumLit test.lkt:9:42-9:44>
      has type <StructDecl prelude: "Int">
 
-Expr <CallExpr test.lkt:9:40-9:47>
+Expr <CallExpr test.lkt:9:38-9:45>
      has type <InstantiatedGenericType prelude: "Array[Int]">
 
-Expr <NumLit test.lkt:9:48-9:49>
+Expr <NumLit test.lkt:9:46-9:47>
      has type <StructDecl prelude: "Int">
 
-test.lkt:9:51: error: ambiguous type for expression
-9 | @incorrect val incorrect_call_2: Int = arr(12)(1, 2)
-  |                                                   ^
+test.lkt:9:49: error: ambiguous type for expression
+9 | @invalid val incorrect_call_2: Int = arr(12)(1, 2)
+  |                                                 ^
 
-Expr <CallExpr test.lkt:9:40-9:53>
+Expr <CallExpr test.lkt:9:38-9:51>
      has type <StructDecl prelude: "Int">
 
 Id   <RefId "Int" test.lkt:11:21-11:24>
@@ -133,25 +133,25 @@ Expr <NumLit test.lkt:13:31-13:32>
 Expr <CallExpr test.lkt:13:14-13:33>
      has type <StructDecl prelude: "Int">
 
-Id   <RefId "Int" test.lkt:14:19-14:22>
+Id   <RefId "Int" test.lkt:14:17-14:20>
      references <StructDecl prelude: "Int">
 
-Id   <RefId "return_func" test.lkt:14:25-14:36>
+Id   <RefId "return_func" test.lkt:14:23-14:34>
      references <FunDecl "return_func" test.lkt:11:1-11:37>
 
-Expr <RefId "return_func" test.lkt:14:25-14:36>
+Expr <RefId "return_func" test.lkt:14:23-14:34>
      has type <FunctionType prelude: "() -> (Int, Int) -> Int">
 
-Expr <CallExpr test.lkt:14:25-14:38>
+Expr <CallExpr test.lkt:14:23-14:36>
      has type <FunctionType prelude: "(Int, Int) -> Int">
 
-Expr <NumLit test.lkt:14:39-14:40>
+Expr <NumLit test.lkt:14:37-14:38>
      has type <StructDecl prelude: "Int">
 
-test.lkt:14:42: error: Mismatched types: expected `Int`, got a character literal
-14 | @incorrect val b: Int = return_func()(1, '2')
-   |                                          ^^^
+test.lkt:14:40: error: Mismatched types: expected `Int`, got a character literal
+14 | @invalid val b: Int = return_func()(1, '2')
+   |                                        ^^^
 
-Expr <CallExpr test.lkt:14:25-14:46>
+Expr <CallExpr test.lkt:14:23-14:44>
      has type <StructDecl prelude: "Int">
 


### PR DESCRIPTION
lkt_toolbox now raise an error if a declaration annotated with
@invalid doesn't emit any diagnostic, and conversely, it also checks
that a diagnostic is related to an @invalid declaration.

TN: UB03-005