### PR TITLE
Use collections.abc.Sequence as the alias is set to be removed

### DIFF
--- a/langkit/templates/python_api/module_py.mako
+++ b/langkit/templates/python_api/module_py.mako
@@ -1503,7 +1503,7 @@ class ${root_astnode_name}:
         if isinstance(ast_type_or_pred, type):
             sought_type = ast_type_or_pred
             pred = lambda node: isinstance(node, sought_type)
-        elif isinstance(ast_type_or_pred, collections.Sequence):
+        elif isinstance(ast_type_or_pred, collections.abc.Sequence):
             sought_types = ast_type_or_pred
             pred = lambda node: isinstance(node, tuple(sought_types))
         else:


### PR DESCRIPTION
Alias has been in place since Py 3.3, and minimum (test) version is 3.8, so I think we're safe

Figured I'd save everyone some time and PR it myself

Closes #580

(I'd have done 579 as well, but need your sign off on my proposed ~hack~workaround to do it)