### PR TITLE
UB16-053: Allow ``No(T.Address)`` expression in properties DSL.

### DIFF
--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -4400,6 +4400,7 @@ def create_builtin_types():
         exposed=False,
         is_ptr=False,
         nullexpr='System.Null_Address',
+        null_allowed=True,
         external=True,
         hashable=True,
     )


### PR DESCRIPTION
This expression is needed in Libadalang for the work on predefined
operators synthesis in order to synthesize nodes that derives from Expr,
as those have a `logic_vars` field with type `Address`.