### PR TITLE
UB16-053: Rename `val` to `value` in env assoc types.

### DIFF
--- a/contrib/lkt/language/parser.py
+++ b/contrib/lkt/language/parser.py
@@ -990,7 +990,7 @@ class LexerDecl(Decl):
             lambda sym:
             new_env_assoc(
                 key=sym,
-                val=SyntheticLexerDecl.new(sym=sym),
+                value=SyntheticLexerDecl.new(sym=sym),
                 dest_env=direct_env(Self.children_env)
             ),
         )
@@ -1881,7 +1881,7 @@ class EnumTypeDecl(NamedTypeDecl):
         # Add enum literals to the DeclBlock env
         add_to_env(Entity.literals.map(lambda lit: new_env_assoc(
                 key=lit.name,
-                val=lit.node,
+                value=lit.node,
                 dest_env=direct_env(Self.decls.children_env),
         ))),
 
@@ -1891,7 +1891,7 @@ class EnumTypeDecl(NamedTypeDecl):
             Entity.full_decl.has_annotation('open'),
             Entity.literals.map(lambda lit: new_env_assoc(
                 key=lit.name,
-                val=lit.node,
+                value=lit.node,
                 dest_env=direct_env(Self.node_env),
             )),
             No(T.env_assoc.array)
@@ -1996,7 +1996,7 @@ class EnumClassDecl(BasicClassDecl):
         handle_children(),
         add_to_env(Entity.alts.map(lambda alt: new_env_assoc(
             key=alt.name,
-            val=alt.node,
+            value=alt.node,
             dest_env=direct_env(Self.decls.children_env),
         )))
     )

--- a/contrib/python/language/parser.py
+++ b/contrib/python/language/parser.py
@@ -65,9 +65,9 @@ class SingleParam(PythonNode):
 
     env_spec = EnvSpec(
         add_to_env(Self.name.match(
-            lambda i=T.Id: new_env_assoc(key=i.sym, val=Self).singleton,
+            lambda i=T.Id: new_env_assoc(key=i.sym, value=Self).singleton,
             lambda l=T.Id.list: l.map(
-                lambda i: new_env_assoc(key=i.sym, val=Self)
+                lambda i: new_env_assoc(key=i.sym, value=Self)
             ),
             lambda _: No(T.env_assoc.array)
         ))
@@ -86,7 +86,7 @@ class AssignStmt(Stmt):
 
     env_spec = EnvSpec(
         add_to_env(Self.l_value.filtermap(
-            lambda e: new_env_assoc(key=e.cast_or_raise(T.Id).sym, val=Self),
+            lambda e: new_env_assoc(key=e.cast_or_raise(T.Id).sym, value=Self),
             lambda e: e.is_a(T.Id),
         ))
     )

--- a/langkit/compiled_types.py
+++ b/langkit/compiled_types.py
@@ -4654,7 +4654,7 @@ class TypeRepo:
         return StructType(
             names.Name('Env_Assoc'), None, None,
             [('key', UserField(type=T.Symbol)),
-             ('val', UserField(type=self.defer_root_node)),
+             ('value', UserField(type=self.defer_root_node)),
              ('dest_env', UserField(type=T.DesignatedEnv)),
              ('metadata', UserField(type=self.defer_env_md))]
         )
@@ -4670,7 +4670,7 @@ class TypeRepo:
         return StructType(
             names.Name('Inner_Env_Assoc'), None, None,
             [('key', UserField(type=T.Symbol)),
-             ('val', UserField(type=self.defer_root_node)),
+             ('value', UserField(type=self.defer_root_node)),
              ('metadata', UserField(type=self.defer_env_md))]
         )
 

--- a/langkit/envs.py
+++ b/langkit/envs.py
@@ -121,7 +121,7 @@ def add_to_env(mappings: AbstractExpression,
 
 
 def add_to_env_kv(key: AbstractExpression,
-                  val: AbstractExpression,
+                  value: AbstractExpression,
                   dest_env: Optional[AbstractExpression] = None,
                   metadata: Optional[AbstractExpression] = None,
                   resolver: Optional[PropertyDef] = None) -> AddToEnv:
@@ -137,7 +137,7 @@ def add_to_env_kv(key: AbstractExpression,
     """
     from langkit.expressions import new_env_assoc
 
-    return add_to_env(new_env_assoc(key, val, dest_env, metadata), resolver)
+    return add_to_env(new_env_assoc(key, value, dest_env, metadata), resolver)
 
 
 def handle_children() -> HandleChildren:

--- a/langkit/expressions/envs.py
+++ b/langkit/expressions/envs.py
@@ -345,13 +345,13 @@ def env_parent(self, env):
     )
 
 
-def new_env_assoc(key, val, dest_env=None, metadata=None):
+def new_env_assoc(key, value, dest_env=None, metadata=None):
     """
     Create a new env assoc, providing basic defaults when fields are not
     specified.
 
     :param AbstractExpression key: The symbol for which to associate a value.
-    :param AbstractExpression val: The node to associate to the key.
+    :param AbstractExpression value: The node to associate to the key.
     :param AbstractExpression dest_env: The environment in which to insert the
         mapping (a DesignatedEnv struct value). If left to None, use the
         current environment.
@@ -360,7 +360,7 @@ def new_env_assoc(key, val, dest_env=None, metadata=None):
     """
     return T.env_assoc.new(
         key=key,
-        val=val,
+        value=value,
         dest_env=current_env() if dest_env is None else dest_env,
         metadata=No(T.defer_env_md) if metadata is None else metadata
     )

--- a/langkit/templates/astnode_types_ada.mako
+++ b/langkit/templates/astnode_types_ada.mako
@@ -318,7 +318,7 @@
            (Self,
             State,
             Mapping.Key,
-            Mapping.Val,
+            Mapping.Value,
             Mapping.Metadata,
             Resolver,
             Mapping.Dest_Env,

--- a/langkit/templates/pkg_implementation_spec_ada.mako
+++ b/langkit/templates/pkg_implementation_spec_ada.mako
@@ -205,7 +205,7 @@ private package ${ada_lib_name}.Implementation is
    is (Self.Key);
    function Get_Node
      (Self : ${T.inner_env_assoc.name}) return ${T.root_node.name}
-   is (Self.Val);
+   is (Self.Value);
    function Get_Metadata
      (Self : ${T.inner_env_assoc.name}) return ${T.env_md.name}
    is (Self.Metadata);

--- a/testsuite/tests/ada_api/properties_introspection/test.py
+++ b/testsuite/tests/ada_api/properties_introspection/test.py
@@ -35,7 +35,7 @@ class VarDecl(FooNode):
     value = Field()
 
     env_spec = EnvSpec(add_to_env_kv(
-        key=Self.name.symbol, val=Self
+        key=Self.name.symbol, value=Self
     ))
 
     @langkit_property(public=True)

--- a/testsuite/tests/lexical_envs/add_to_env_foreign/test.py
+++ b/testsuite/tests/lexical_envs/add_to_env_foreign/test.py
@@ -26,7 +26,7 @@ class Scope(FooNode):
     content = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env()
     )
 
@@ -91,7 +91,7 @@ class ForeignDecl(FooNode):
 
     env_spec = EnvSpec(
         add_to_env_kv(
-            key=Self.id.simple_name.symbol, val=Self.node_for_env,
+            key=Self.id.simple_name.symbol, value=Self.node_for_env,
             dest_env=direct_env(Self.id.match(
                 lambda simple=T.SimpleId:
                     simple.node_env,
@@ -109,7 +109,7 @@ class SelfDecl(FooNode):
     env_spec = EnvSpec(
         add_to_env_kv(
             key=Self.id.simple_name.symbol,
-            val=Self.id.resolve(Self.node_env),
+            value=Self.id.resolve(Self.node_env),
             metadata=New(
                 T.Metadata,
                 node=Self.md_node.then(lambda n: n.resolve(Self.node_env))

--- a/testsuite/tests/lexical_envs/add_to_env_mult_dests/test.py
+++ b/testsuite/tests/lexical_envs/add_to_env_mult_dests/test.py
@@ -32,7 +32,7 @@ class Scope(FooNode):
             Self.content.children.map(
                 lambda r: new_env_assoc(
                     key="Scope",
-                    val=Self,
+                    value=Self,
                     dest_env=direct_env(r.match(
                         lambda s=T.Scope: s.name.children_env,
                         lambda _: r.children_env

--- a/testsuite/tests/lexical_envs/add_to_env_nonprimary/test.py
+++ b/testsuite/tests/lexical_envs/add_to_env_nonprimary/test.py
@@ -22,7 +22,7 @@ class Example(FooNode):
         add_to_env(
             new_env_assoc(
                 key="foo",
-                val=Self,
+                value=Self,
                 dest_env=direct_env(Self.children_env.env_orphan),
             )
         )

--- a/testsuite/tests/lexical_envs/add_to_foreign_env/test.py
+++ b/testsuite/tests/lexical_envs/add_to_foreign_env/test.py
@@ -26,7 +26,7 @@ class Scope(FooNode):
     content = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env()
     )
 
@@ -63,7 +63,7 @@ class ForeignDecl(FooNode):
     env_spec = EnvSpec(
         add_to_env_kv(
             key=Self.decl_id.symbol,
-            val=Self,
+            value=Self,
             dest_env=direct_env(
                 Self.dest_scope.resolve(Self.parent.children_env).children_env
             ),

--- a/testsuite/tests/lexical_envs/direct_env/test.py
+++ b/testsuite/tests/lexical_envs/direct_env/test.py
@@ -35,7 +35,7 @@ class Example(FooNode):
         add_env(),
         add_to_env_kv(
             key=Self.name.symbol,
-            val=Self,
+            value=Self,
 
             # Check correct behavior when the env argument is null or not (when
             # it's not, add to the parents' env), and when or_current=True is

--- a/testsuite/tests/lexical_envs/dump_envs/test.py
+++ b/testsuite/tests/lexical_envs/dump_envs/test.py
@@ -22,14 +22,14 @@ class Scope(FooNode):
     name = Field(type=Identifier)
     content = Field()
 
-    env_spec = EnvSpec(add_to_env_kv(key=Self.name.symbol, val=Self),
+    env_spec = EnvSpec(add_to_env_kv(key=Self.name.symbol, value=Self),
                        add_env())
 
 
 class Decl(FooNode):
     id = Field(type=Identifier)
 
-    env_spec = EnvSpec(add_to_env_kv(key=Self.id.symbol, val=Self))
+    env_spec = EnvSpec(add_to_env_kv(key=Self.id.symbol, value=Self))
 
 
 build_and_run(lkt_file='expected_concrete_syntax.lkt', py_script='main.py')

--- a/testsuite/tests/lexical_envs/entity_resolver/test.py
+++ b/testsuite/tests/lexical_envs/entity_resolver/test.py
@@ -29,7 +29,7 @@ class Decl(FooNode):
 
     env_spec = EnvSpec(
         add_to_env_kv(
-            key=Self.name.symbol, val=Self
+            key=Self.name.symbol, value=Self
         ),
         add_env()
     )
@@ -39,7 +39,7 @@ class Ref(FooNode):
     name = Field()
 
     env_spec = EnvSpec(add_to_env_kv(
-        key=Self.name.symbol, val=Self,
+        key=Self.name.symbol, value=Self,
         resolver=FooNode.resolve_ref
     ))
 

--- a/testsuite/tests/lexical_envs/get_error_leak/test.py
+++ b/testsuite/tests/lexical_envs/get_error_leak/test.py
@@ -27,7 +27,7 @@ class Scope(FooNode):
     content = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env()
     )
 

--- a/testsuite/tests/lexical_envs/invalid_entity_resolver/test.py
+++ b/testsuite/tests/lexical_envs/invalid_entity_resolver/test.py
@@ -28,7 +28,7 @@ def run(name, prop):
 
         env_spec = EnvSpec(
             add_to_env_kv(
-                key=Self.name.symbol, val=Self
+                key=Self.name.symbol, value=Self
             ),
             add_env()
         )
@@ -37,7 +37,7 @@ def run(name, prop):
         name = Field()
 
         env_spec = EnvSpec(add_to_env_kv(
-            key=Self.name.symbol, val=Self,
+            key=Self.name.symbol, value=Self,
             resolver=FooNode.resolve_ref
         ))
 

--- a/testsuite/tests/lexical_envs/lexical_env_loop/test.py
+++ b/testsuite/tests/lexical_envs/lexical_env_loop/test.py
@@ -39,7 +39,7 @@ class Package(Decl):
     decls = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env()
     )
 
@@ -56,7 +56,7 @@ class Var(Decl):
     name = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self)
+        add_to_env_kv(key=Self.name.symbol, value=Self)
     )
 
 

--- a/testsuite/tests/lexical_envs/named_env/test.py
+++ b/testsuite/tests/lexical_envs/named_env/test.py
@@ -36,7 +36,7 @@ class Example(FooNode):
         add_env(names=[Self.name.symbol]),
         add_to_env_kv(
             key=Self.name.symbol,
-            val=Self,
+            value=Self,
 
             # Check correct behavior when the env argument is null or not (when
             # it's not, add to the parents' env), and when or_current=True is

--- a/testsuite/tests/lexical_envs/ple_after_reparse/test.py
+++ b/testsuite/tests/lexical_envs/ple_after_reparse/test.py
@@ -84,7 +84,7 @@ class Scope(FooNode):
                 direct_env(Self.parent.children_env),
             ),
         ),
-        add_to_env_kv(key=Self.name.suffix_symbol, val=Self),
+        add_to_env_kv(key=Self.name.suffix_symbol, value=Self),
         add_env(names=[Self.name.fqn.to_symbol]),
     )
 
@@ -100,7 +100,7 @@ class Var(FooNode):
     value = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
     )
 
 

--- a/testsuite/tests/lexical_envs/ple_resilience/test.py
+++ b/testsuite/tests/lexical_envs/ple_resilience/test.py
@@ -58,7 +58,7 @@ class Scope(DefNode):
     defs = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env(),
         do(If(Self.error.as_bool,
               PropertyError(T.FooNode),
@@ -71,7 +71,7 @@ class Var(DefNode):
     value = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
     )
 
 

--- a/testsuite/tests/lexical_envs/ref_after_reparse/test.py
+++ b/testsuite/tests/lexical_envs/ref_after_reparse/test.py
@@ -40,7 +40,7 @@ class Block(FooNode):
     refs = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env()
     )
 
@@ -49,7 +49,7 @@ class Decl(FooNode):
     name = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self)
+        add_to_env_kv(key=Self.name.symbol, value=Self)
     )
 
 

--- a/testsuite/tests/lexical_envs/ref_env_foreign/test.py
+++ b/testsuite/tests/lexical_envs/ref_env_foreign/test.py
@@ -19,7 +19,7 @@ class Scope(FooNode):
     content = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env()
     )
 

--- a/testsuite/tests/lexical_envs/set_initial_foreign_env/test.py
+++ b/testsuite/tests/lexical_envs/set_initial_foreign_env/test.py
@@ -29,7 +29,7 @@ class Scope(FooNode):
         set_initial_env(
             direct_env(Self.name.designated_scope(Self.parent.children_env))
         ),
-        add_to_env_kv(key=Self.name.designated_symbol, val=Self),
+        add_to_env_kv(key=Self.name.designated_symbol, value=Self),
         add_env(),
     )
 

--- a/testsuite/tests/lexical_envs/sorted_foreign/test.py
+++ b/testsuite/tests/lexical_envs/sorted_foreign/test.py
@@ -94,7 +94,7 @@ class Scope(FooNode):
                 default_val=direct_env(Self.parent.children_env),
             ),
         ),
-        add_to_env_kv(key=Self.name.referenced_name, val=Self),
+        add_to_env_kv(key=Self.name.referenced_name, value=Self),
         add_env(names=[Self.name.fqn.to_symbol])
     )
 

--- a/testsuite/tests/properties/auto_ple_dispatcher/test.py
+++ b/testsuite/tests/properties/auto_ple_dispatcher/test.py
@@ -46,7 +46,7 @@ class Scope(DefNode):
     defs = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env(),
     )
 
@@ -56,7 +56,7 @@ class Var(DefNode):
     value = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
     )
 
 

--- a/testsuite/tests/properties/auto_populate/test.py
+++ b/testsuite/tests/properties/auto_populate/test.py
@@ -22,7 +22,7 @@ class Decl(FooNode):
     items = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self)
+        add_to_env_kv(key=Self.name.symbol, value=Self)
     )
 
 

--- a/testsuite/tests/properties/big_integer/test.py
+++ b/testsuite/tests/properties/big_integer/test.py
@@ -24,7 +24,7 @@ class Decl(FooNode):
     expr_tree = Field(type=T.Expr)
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self)
+        add_to_env_kv(key=Self.name.symbol, value=Self)
     )
 
 

--- a/testsuite/tests/properties/domain_derived/test.py
+++ b/testsuite/tests/properties/domain_derived/test.py
@@ -18,7 +18,7 @@ class Definition(FooNode):
     name = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self)
+        add_to_env_kv(key=Self.name.symbol, value=Self)
     )
 
 

--- a/testsuite/tests/properties/dyn_env/test.py
+++ b/testsuite/tests/properties/dyn_env/test.py
@@ -31,7 +31,7 @@ class ConsDecl(FooNode):
     env_spec = EnvSpec(
         add_to_env(T.env_assoc.new(
             key=Self.name.symbol,
-            val=Self,
+            value=Self,
             dest_env=current_env(),
             metadata=No(T.Metadata),
         ))
@@ -50,7 +50,7 @@ class FunDecl(FooNode):
     env_spec = EnvSpec(
         add_to_env(T.env_assoc.new(
             key=Self.name.symbol,
-            val=Self,
+            value=Self,
             dest_env=current_env(),
             metadata=No(T.Metadata),
         ))
@@ -82,7 +82,7 @@ class CallExpr(FooNode):
         """
         decl = Var(Self.node_env.get_first(Self.name).cast(T.FunDecl))
         return decl.args.map(lambda i, a: T.inner_env_assoc.new(
-            key=a.name.symbol, val=Self.args.at(i), metadata=No(T.env_md)
+            key=a.name.symbol, value=Self.args.at(i), metadata=No(T.env_md)
         ))
 
     @langkit_property(return_type=T.inner_env_assoc.array)
@@ -92,7 +92,7 @@ class CallExpr(FooNode):
         """
         decl = Var(Self.node_env.get_first(Self.name).cast(T.FunDecl))
         return decl.args.map(lambda a: T.inner_env_assoc.new(
-            key=a.name.symbol, val=a.arg_expr.node, metadata=No(T.env_md)
+            key=a.name.symbol, value=a.arg_expr.node, metadata=No(T.env_md)
         ))
 
     # Entry points for the test program

--- a/testsuite/tests/properties/dynvar_bind/test.py
+++ b/testsuite/tests/properties/dynvar_bind/test.py
@@ -22,7 +22,7 @@ class Decl(FooNode):
 
     env_spec = EnvSpec(
         add_to_env_kv(
-            key=Self.name.symbol, val=Self
+            key=Self.name.symbol, value=Self
         ),
         add_env()
     )
@@ -33,7 +33,7 @@ class Ref(FooNode):
 
     env_spec = EnvSpec(
         add_to_env_kv(
-            key=Self.name.symbol, val=Self
+            key=Self.name.symbol, value=Self
         )
     )
 

--- a/testsuite/tests/properties/entity_map/test.py
+++ b/testsuite/tests/properties/entity_map/test.py
@@ -37,7 +37,7 @@ class Decl(FooNode):
     items = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self,
+        add_to_env_kv(key=Self.name.symbol, value=Self,
                       metadata=New(Metadata, b=Self.has_plus.as_bool))
     )
 

--- a/testsuite/tests/properties/equality/test.py
+++ b/testsuite/tests/properties/equality/test.py
@@ -40,7 +40,7 @@ class Decl(FooNode):
     items = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env(),
     )
 

--- a/testsuite/tests/properties/is_visible_from/test.py
+++ b/testsuite/tests/properties/is_visible_from/test.py
@@ -24,7 +24,7 @@ class Name(FooNode):
     token_node = True
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.symbol, val=Self),
+        add_to_env_kv(key=Self.symbol, value=Self),
         add_env()
     )
 

--- a/testsuite/tests/properties/logging/test.py
+++ b/testsuite/tests/properties/logging/test.py
@@ -34,7 +34,7 @@ class Decl(FooNode):
     items = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self,
+        add_to_env_kv(key=Self.name.symbol, value=Self,
                       metadata=New(Metadata, b=Self.has_plus.as_bool))
     )
 

--- a/testsuite/tests/properties/lower_dispatch/test.py
+++ b/testsuite/tests/properties/lower_dispatch/test.py
@@ -107,7 +107,7 @@ class Def(FooNode):
     expr = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self)
+        add_to_env_kv(key=Self.name.symbol, value=Self)
     )
 
 

--- a/testsuite/tests/properties/lower_dispatch_rewrite/test.py
+++ b/testsuite/tests/properties/lower_dispatch_rewrite/test.py
@@ -73,7 +73,7 @@ class Var(FooNode):
     expr = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
     )
 
 
@@ -84,7 +84,7 @@ class Def(FooNode):
     expr = Field()
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name.symbol, val=Self),
+        add_to_env_kv(key=Self.name.symbol, value=Self),
         add_env(),
         reference(Self.imports.map(lambda i: i.cast(T.FooNode)),
 

--- a/testsuite/tests/properties/memoized_env/test.py
+++ b/testsuite/tests/properties/memoized_env/test.py
@@ -31,7 +31,7 @@ class Block(FooNode):
 
     env_spec = EnvSpec(
         add_env(),
-        add_to_env_kv(key=Self.name.symbol, val=Self,
+        add_to_env_kv(key=Self.name.symbol, value=Self,
                       dest_env=direct_env(Self.node_env)),
     )
 

--- a/testsuite/tests/properties/rebindings/test.py
+++ b/testsuite/tests/properties/rebindings/test.py
@@ -22,7 +22,7 @@ class Name(FooNode):
 class DefNode(FooNode):
     name = AbstractProperty(T.Symbol, public=True)
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name, val=Self)
+        add_to_env_kv(key=Self.name, value=Self)
     )
 
 
@@ -66,7 +66,7 @@ class Block(DefNode):
                 .as_bare_entity)
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name, val=Self),
+        add_to_env_kv(key=Self.name, value=Self),
         add_env()
     )
 

--- a/testsuite/tests/python_api/entity_eq/test.py
+++ b/testsuite/tests/python_api/entity_eq/test.py
@@ -23,7 +23,7 @@ class Name(FooNode):
 class DefNode(FooNode):
     name = AbstractProperty(T.Symbol, public=True)
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name, val=Self)
+        add_to_env_kv(key=Self.name, value=Self)
     )
 
 
@@ -49,7 +49,7 @@ class Block(DefNode):
         return New(Block.entity, node=Self, info=e_info)
 
     env_spec = EnvSpec(
-        add_to_env_kv(key=Self.name, val=Self),
+        add_to_env_kv(key=Self.name, value=Self),
         add_env()
     )
 

--- a/testsuite/tests/structs/foreign_env_md/test.py
+++ b/testsuite/tests/structs/foreign_env_md/test.py
@@ -32,7 +32,7 @@ class Def(FooNode):
 
     env_spec = EnvSpec(
         add_to_env_kv(
-            key=Self.name.sym, val=Self,
+            key=Self.name.sym, value=Self,
             metadata=New(Metadata, node=Self.ref.then(
                 lambda r: r.resolve.node,
                 default_val=No(T.FooNode)


### PR DESCRIPTION
Since `val` is a keyword in Lkt, dsl_unparse fails on expressions that retrieve this
component from an env_assoc value. In particular, such expressions are now used in
Libadalang as part of the changes made under this TN.