### PR TITLE
Use gnatcoll_gmp static library

### DIFF
--- a/langkit/libmanage.py
+++ b/langkit/libmanage.py
@@ -897,6 +897,7 @@ class ManageScript:
         result = ['-XBUILD_MODE={}'.format(self.build_mode),
                   '-XLIBRARY_TYPE={}'.format(library_type),
                   '-XGPR_BUILD={}'.format(library_type),
+                  '-XGNATCOLL_GMP_BUILD={}'.format(library_type),
                   '-XXMLADA_BUILD={}'.format(library_type)]
 
         if self.enable_build_warnings:

--- a/testsuite/python_support/utils.py
+++ b/testsuite/python_support/utils.py
@@ -381,6 +381,7 @@ def build_and_run(grammar=None, py_script=None, ada_main=None, lexer=None,
             ))
         run('gprbuild', '-Pgen', '-q', '-p',
             '-XLIBRARY_TYPE=static',
+            '-XGNATCOLL_GMP_BUILD=static',
             '-XXMLADA_BUILD=static')
 
         for i, m in enumerate(ada_main):


### PR DESCRIPTION
If gnatcoll_gmp has been built supporting static & relocatable libraries, it uses relocatable, and test fails when mixing static and relocatable libraries