### PR TITLE
Stop depending on the funcy non-standard module

### DIFF
--- a/REQUIREMENTS.dev
+++ b/REQUIREMENTS.dev
@@ -3,7 +3,6 @@ coverage==5.1
 docutils==0.16
 -e git+https://github.com/AdaCore/e3-core.git#egg=e3-core
 -e git+https://github.com/AdaCore/e3-testsuite.git#egg=e3-testsuite
-funcy==1.14
 Mako==1.1.2
 sphinx-rtd-theme==0.4.3
 yapf==0.30.0

--- a/langkit/compile_context.py
+++ b/langkit/compile_context.py
@@ -21,8 +21,6 @@ from os import path
 from typing import (Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING,
                     Tuple, Union, cast)
 
-from funcy import lzip
-
 from langkit import documentation, names, utils
 from langkit.ada_api import AdaAPISettings
 from langkit.c_api import CAPISettings
@@ -2671,8 +2669,8 @@ class CompileCtx:
                 dispatch_types, remainder = collapse_concrete_nodes(
                     prop.struct, reversed([p.struct for p in static_props]))
                 assert not remainder
-                prop.dispatch_table = lzip(reversed(dispatch_types),
-                                           static_props)
+                prop.dispatch_table = list(zip(reversed(dispatch_types),
+                                               static_props))
                 # TODO: emit a warning for unreachable properties earlier in
                 # the compilation pipeline. Here we can see them with an empty
                 # set of types in the dispatch table.

--- a/langkit/emitter.py
+++ b/langkit/emitter.py
@@ -9,8 +9,6 @@ from os import path
 import subprocess
 from typing import Any, Callable, Dict, List, Optional, Set
 
-from funcy import keep
-
 from langkit.caching import Cache
 from langkit.compile_context import AdaSourceKind, CompileCtx, get_context
 from langkit.coverage import InstrumentationMetadata
@@ -217,7 +215,8 @@ class Emitter:
         if self.extensions_dir:
             add_template_dir(self.extensions_dir)
 
-        for dirpath in keep(self.context.template_lookup_extra_dirs):
+        for dirpath in self.context.template_lookup_extra_dirs:
+          if dirpath:
             add_template_dir(dirpath)
 
         self.no_property_checks = no_property_checks

--- a/langkit/envs.py
+++ b/langkit/envs.py
@@ -9,7 +9,6 @@ introduction to their usage.
 from __future__ import annotations
 
 from enum import Enum
-from funcy import lsplit_by
 from itertools import count
 from typing import ContextManager, Dict, List, Optional, Type, cast, overload
 
@@ -238,10 +237,10 @@ class EnvSpec:
 
         # Separate actions that must occur before and after the handling of
         # children. Get also rid of the HandleChildren delimiter action.
-        pre, post = lsplit_by(lambda a: not isinstance(a, HandleChildren),
-                              actions)
-        post = post and post[1:]
-
+        hc = next(filter(lambda i: isinstance(actions[i], HandleChildren),
+                         range(len(actions))),
+                  default = len(actions))
+        pre, post = actions[:hc], actions[hc+1:]
         check_source_language(
             count(AddEnv, post) == 0,
             'add_env() must occur before processing children'

--- a/langkit/expressions/boolean.py
+++ b/langkit/expressions/boolean.py
@@ -1,5 +1,4 @@
 from functools import reduce
-import funcy
 import inspect
 
 from langkit import names
@@ -571,7 +570,8 @@ class Cond(AbstractExpression):
 
         :rtype: list[(AbstractExpression, AbstractExpression)]
         """
-        return funcy.lpartition(2, self.args)
+        it = iter(self.args)
+        return list(zip(it, it))
 
     @property
     def else_expr(self):

--- a/langkit/expressions/collections.py
+++ b/langkit/expressions/collections.py
@@ -5,8 +5,6 @@ from itertools import count
 import types
 from typing import Callable, List, Optional, Union
 
-import funcy
-
 from langkit import names
 from langkit.compiled_types import CompiledType, get_context
 from langkit.diagnostics import (
@@ -354,7 +352,7 @@ class CollectionExpression(AbstractExpression):
 
         return self.ConstructCommonResult(
             collection_expr,
-            funcy.lzip(elt_vars, elt_var_inits),
+            list(zip(elt_vars, elt_var_inits)),
             construct(self.index_var) if self.index_var else None,
             inner_expr,
             inner_scope

--- a/langkit/expressions/logic.py
+++ b/langkit/expressions/logic.py
@@ -1,8 +1,6 @@
 from itertools import zip_longest
 from typing import Any as _Any, List, Optional, Tuple, Union
 
-import funcy
-
 from langkit import names
 from langkit.compiled_types import Argument, T, no_compiled_type
 from langkit.diagnostics import check_multiple, check_source_language, error
@@ -625,9 +623,11 @@ class Predicate(AbstractExpression):
 
         # Separate logic variable expressions from extra argument expressions
         exprs = [construct(e) for e in self.exprs]
-        logic_var_exprs, closure_exprs = funcy.lsplit_by(
-            lambda e: e.type == T.LogicVar, exprs
-        )
+        first_extra = next(filter(lambda i: exprs[i].type == T.LogicVar,
+                                  range(len(exprs))),
+                           default = len(exprs))
+        logic_var_exprs, closure_exprs = exprs[:first_extra], exprs [first_extra:]
+
         check_source_language(
             len(logic_var_exprs) > 0, "Predicate instantiation should have at "
             "least one logic variable expression"

--- a/langkit/expressions/structs.py
+++ b/langkit/expressions/structs.py
@@ -4,8 +4,6 @@ import inspect
 from typing import (Any as _Any, ContextManager, Dict, List, Optional,
                     Sequence, Tuple)
 
-import funcy
-
 from langkit import names
 from langkit.compiled_types import (
     ASTNodeType, AbstractNodeData, Field, resolve_type
@@ -806,10 +804,8 @@ class FieldAccess(AbstractExpression):
             call_debug_info = (isinstance(self.node_data, PropertyDef)
                                and not self.node_data.external)
 
-            sub_exprs = [self.receiver_expr] + funcy.lfilter(
-                lambda e: e is not None,
-                self.arguments
-            )
+            sub_exprs = (self.receiver_expr,
+                         *(e for e in self.arguments if e is not None))
             result = [e.render_pre() for e in sub_exprs]
 
             if call_debug_info:

--- a/langkit/parsers.py
+++ b/langkit/parsers.py
@@ -25,15 +25,12 @@ from __future__ import annotations
 from collections import OrderedDict
 from contextlib import contextmanager
 import difflib
-from funcy import keep
 import inspect
 from itertools import count
 from typing import (
     Any, Callable, ContextManager, Dict, Iterator, List as _List, Optional,
     Sequence, Set, TYPE_CHECKING, Tuple, Type, Union
 )
-
-import funcy
 
 from langkit import names
 from langkit.common import gen_name
@@ -1547,7 +1544,7 @@ class List(Parser):
 
     @property
     def children(self) -> _List[Parser]:
-        return keep([self.parser, self.sep])
+        return filter(None, [self.parser, self.sep])
 
     def _eval_type(self) -> Optional[CompiledType]:
         with self.diagnostic_context:
@@ -2047,8 +2044,8 @@ class _Transform(Parser):
     def generate_code(self) -> str:
         subparsers: _List[Tuple[Parser, VarDef]]
         if isinstance(self.parser, _Row):
-            subparsers = funcy.lzip(self.parser.parsers,
-                                    self.parser.subresults)
+            subparsers = zip(self.parser.parsers,
+                             self.parser.subresults)
         else:
             subparsers = [(self.parser, self.parser.res_var)]
 

--- a/langkit/unparsers.py
+++ b/langkit/unparsers.py
@@ -8,8 +8,6 @@ from io import StringIO
 import itertools
 import sys
 
-import funcy
-
 from langkit.common import text_repr
 from langkit.compiled_types import get_context, resolve_type
 from langkit.diagnostics import WarningSet, check_source_language
@@ -789,8 +787,8 @@ class RegularNodeUnparser(NodeUnparser):
 
         :rtype: list[(FieldUnparser, TokenSequenceUnparser)]
         """
-        return funcy.lzip(self.field_unparsers,
-                          [TokenSequenceUnparser()] + self.inter_tokens)
+        return list(zip(self.field_unparsers,
+                        [TokenSequenceUnparser()] + self.inter_tokens))
 
     def _dump(self, stream):
         stream.write('Unparser for {}:\n'.format(self.node.dsl_name))

--- a/langkit/utils/__init__.py
+++ b/langkit/utils/__init__.py
@@ -206,11 +206,10 @@ def add_to_path(env: Dict[str, str], name: str, item: str) -> None:
     """
     Add ``item`` to the ``name`` path environment variable in ``env``.
     """
-    # GDB helpers import this unit, but they do not necessarily have access to
-    # funcy, so use a local import.
-    from funcy import keep
-
-    env[name] = os.path.pathsep.join(keep([item, env.get(name, '')]))
+    if name in env:
+        env[name] = item + os.path.pathsep + env[name]
+    else:
+        env[name] = item
 
 
 def format_setenv(name: str, path: str) -> str:

--- a/mypy.ini
+++ b/mypy.ini
@@ -95,9 +95,6 @@ disallow_untyped_decorators = True
 [mypy-e3.*]
 ignore_missing_imports = True
 
-[mypy-funcy.*]
-ignore_missing_imports = True
-
 [mypy-gdb.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='report@adacore.com',
     url='https://www.adacore.com',
     description='A Python framework to generate language parsers',
-    install_requires=['Mako', 'PyYAML', 'funcy', 'docutils', 'e3-core'],
+    install_requires=['Mako', 'PyYAML', 'docutils', 'e3-core'],
     packages=['langkit',
               'langkit.expressions',
               'langkit.gdb',


### PR DESCRIPTION
Each dependency outside the standard library slightly increases the
maintenance cost and the difficulty for new contributors.

Readability is always subjective, but performances are critical for
langkit and the changes introduced by this commit should sligthly
improve it:
* Several intermediate list constructions are replaced by integer
  list/tuple indices or Python generators.
* In langkit/expressions/base.py, traversal of a tree by a recursive
  generator is replaced with a single loop.  Moreover, according to
  https://github.com/Suor/funcy/blob/master/funcy/tree.py, the funcy
  implementation uses a deque structure while only right-appends are
  actually needed.

The only dubious change in langkit/dsl_unparse.py constructs an
intermediate tuple, but the previous version was concatenating
intermediate lists, which is slightly worst.