### PR TITLE
create-project.py: forward verbosity option

### DIFF
--- a/scripts/create-project.py
+++ b/scripts/create-project.py
@@ -55,7 +55,8 @@ class Manage(ManageScript):
 
         return CompileCtx(lang_name={lang_name_repr},
                           lexer={lang_name_slug}_lexer,
-                          grammar={lang_name_slug}_grammar)
+                          grammar={lang_name_slug}_grammar,
+                          verbosity=args.verbosity)
 
 if __name__ == '__main__':
     Manage().run()


### PR DESCRIPTION
Hi, this is a change that makes it easier to turn on verbose mode completely.

I also considered setting `self.context.verbosity` directly in `class ManageScript`, but I think that would have changed the API.