### PR TITLE
setup.py: add missing langkit.scripts package to wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
               'langkit.expressions',
               'langkit.gdb',
               'langkit.lexer',
+              'langkit.scripts',
               'langkit.stylechecks',
               'langkit.utils'],
     package_data={'langkit': [


### PR DESCRIPTION
The "create-project.py" executable wrapper file created by setuptools was crashing with an error:

    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "C:/Users/User/Documents/Programs/msys64-1/msys64/ucrt64/bin/create-project.exe/__main__.py", line 4, in <module>
    ModuleNotFoundError: No module named 'langkit.scripts'

because the source file "langkit/scripts/create_project.py" was not added to the wheel archive.