### PR TITLE
setup.py: rename Windows executable from 'create-project.py.exe' to 'create-project.exe'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ]},
     entry_points={
         "console_scripts": [
-            "create-project.py = langkit.scripts.create_project:main",
+            "create-project = langkit.scripts.create_project:main",
         ]
     },
 )


### PR DESCRIPTION
It is not necessary to add the `.py` suffix to the script name of the console entry point.

For each `console_scripts` entry point in `setup.py`, setuptools generates a wrapper executable, which is not itself a Python script. For example, on Windows, it would produce a standard PE binary with name `create-project.py.exe` that calls the Python interpreter with the configured script.